### PR TITLE
⏲ Implement object path tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "webpack": "^2.5.1"
   },
   "dependencies": {
-    "fast-json-patch": "^1.1.8"
+    "fast-json-patch": "^2.0.0"
   }
 }

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -191,6 +191,7 @@ const JSONPatcherProxy = (function() {
           const proxyInstance = instance.proxifiedObjectsMap.get(target[key]);
 
           if (proxyInstance) {
+            instance.objectsPathsMap.delete(proxyInstance.originalObject);
             instance.disableTrapsForProxy(proxyInstance.proxy);
             instance.proxifiedObjectsMap.delete(target[key]);
           }

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,7 @@
     <script src="lib/jasmine-2.5.0/jasmine-html.js"></script>
     <!-- <script src="lib/jasmine-2.5.0/boot.js"></script> -->
     <script src="lib/jasmine-custom-boot.js"></script>
-    <script src="https://rawgit.com/Starcounter-Jack/JSON-Patch/master/dist/json-patch-duplex.min.js"></script>
+    <script src="https://rawgit.com/Starcounter-Jack/JSON-Patch/master/dist/fast-json-patch.min.js"></script>
 
     <!-- include Benchmark.js -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
@@ -23,7 +23,7 @@
 
 
     <!-- include source files here... -->
-    <script src="../dist/jsonpatcherproxy.min.js"></script>
+    <script src="../src/jsonpatcherproxy.js"></script>
 
     <!-- include spec files here... -->
     <script src="spec/proxyBenchmark.js"></script>


### PR DESCRIPTION
Explanation:

### How do we proxify objects?

1. Create a new `tree` object.
2. Iterate all `originalObject` properties and `proxify` them one by one. Copy each proxified prop to `tree`.
3. `proxify` function would pass `path` to ES6 proxy traps (`set` and `deleteProperty`). Because it knows where is it in the object tree throughout traversing. 

All done, now we have a proxified tree with a set of proxies that have `set` functions caching `path` inside them.

Looks fine.

### Until

The project tree is mutated in a way that doesn't affect the deep proxy itself but changes its path. Like:

```js
tree = [{value: 1}, {value: 2}]
tree.shift();
```
Now tree is `[{value: 2}]`, and `2` thinks its path is `/1/value`.
```js
tree[0].value = 3;

// would emit {op: replace, path: /1/value, value: 3}. Which is bad.
```
This PR makes JP keep track of all proxies' paths and updates them if needed after every mutation.

Fixes: https://github.com/Palindrom/JSONPatcherProxy/issues/9 and more.



