### PR TITLE
⏲ Re-engineer path tracking and proxification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_script:
 node_js: 6
 script:
   - xvfb-run npm test
+  - xvfb-run npm run bench

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Returns  a `Proxy` mirror of your object.
 - Note 1: you must either set `record` to `true` or pass a callback.
 - Note 2: you have to use the return value of this function as your object of interest. Changes to the original object will go unnoticed.
 - Note 3: please make sure to call `JSONPatcherProxy#generate` often if you choose to record. Because the patches will accumulate if you don't.
-- Note 4: the returned mirror object has a property `_isProxified` set to true, you can use this to tell an object and its mirror apart. Also if your `root` object or any deep object inside it has `_isProxified` property set to `true` it won't be proxified => will not emit patches.
 
 #### JSONPatcherProxy#generate () :  Array
 

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -8,19 +8,180 @@
 
 /** Class representing a JS Object observer  */
 const JSONPatcherProxy = (function() {
+  function setTrap(instance, target, key, newValue) {
+
+    const parentPath = findObjectPath(instance, target);
+
+    var destinationPropKey = parentPath + '/' + escapePathComponent(key);
+    {
+      if (instance.proxifiedObjectsMap.has(newValue)) {
+        var newValueOriginalObject = instance.proxifiedObjectsMap.get(newValue);
+
+        instance.parenthoodMap.set(newValueOriginalObject.originalObject, {
+          parent: target,
+          path: key
+        });
+      }
+      /*
+        mark already proxified values as inherited.
+        rationale: proxy.arr.shift()
+        will emit
+        {op: replace, path: '/arr/1', value: arr_2}
+        {op: remove, path: '/arr/2'}
+
+        by default, the second operation would revoke the proxy, and this renders arr revoked.
+        That's why we need to remember the proxies that are inherited.
+      */
+      const revokableInstance = instance.proxifiedObjectsMap.get(newValue);
+      /*
+          Why do we need to check instance.isProxifyingTreeNow?
+
+          We need to make sure we mark revokables as inherited ONLY when we're observing,
+          because throughout the first proxification, a sub-object is proxified and then assigned to 
+          its parent object. This assignment of a pre-proxified object can fool us into thinking
+          that it's a proxified object moved around, while in fact it's the first assignment ever. 
+
+          Checking isProxifyingTreeNow ensures this is not happening in the first proxification, 
+          but in fact is is a proxified object moved around the tree
+          */
+      if (revokableInstance && !instance.isProxifyingTreeNow) {
+        revokableInstance.inherited = true;
+      }
+    }
+    // if the new value is an object, make sure to watch it
+    if (
+      newValue &&
+      typeof newValue == 'object' &&
+      !instance.proxifiedObjectsMap.has(newValue)
+    ) {
+      instance.parenthoodMap.set(newValue, {
+        parent: target,
+        path: key
+      });
+      newValue = instance._proxifyObjectTreeRecursively(target, newValue, key);
+    }
+    if (typeof newValue == 'undefined') {
+      if (target.hasOwnProperty(key)) {
+        // when array element is set to `undefined`, should generate replace to `null`
+        if (Array.isArray(target)) {
+          //undefined array elements are JSON.stringified to `null`
+          instance.defaultCallback({
+            op: 'replace',
+            path: destinationPropKey,
+            value: null
+          });
+        } else {
+          instance.defaultCallback({
+            op: 'remove',
+            path: destinationPropKey
+          });
+        }
+        return Reflect.set(target, key, newValue);
+      } else if (!Array.isArray(target)) {
+        return Reflect.set(target, key, newValue);
+      }
+    }
+    if (Array.isArray(target) && !Number.isInteger(+key.toString())) {
+      return Reflect.set(target, key, newValue);
+    }
+    if (target.hasOwnProperty(key)) {
+      if (typeof target[key] == 'undefined') {
+        if (Array.isArray(target)) {
+          instance.defaultCallback({
+            op: 'replace',
+            path: destinationPropKey,
+            value: newValue
+          });
+        } else {
+          instance.defaultCallback({
+            op: 'add',
+            path: destinationPropKey,
+            value: newValue
+          });
+        }
+        return Reflect.set(target, key, newValue);
+      } else {
+        instance.defaultCallback({
+          op: 'replace',
+          path: destinationPropKey,
+          value: newValue
+        });
+        return Reflect.set(target, key, newValue);
+      }
+    } else {
+      instance.defaultCallback({
+        op: 'add',
+        path: destinationPropKey,
+        value: newValue
+      });
+      return Reflect.set(target, key, newValue);
+    }
+  }
+  function deleteTrap(instance, target, key) {
+    debugger;
+    if (typeof target[key] !== 'undefined') {
+      const parentPath = findObjectPath(instance, target);
+
+      const destinationPropKey = parentPath + '/' + escapePathComponent(key);
+
+      instance.defaultCallback({
+        op: 'remove',
+        path: destinationPropKey
+      });
+      const revokableProxyInstance = instance.proxifiedObjectsMap.get(
+        target[key]
+      );
+
+      if (revokableProxyInstance) {
+        if (revokableProxyInstance.inherited) {
+          /*
+            this is an inherited proxy (an already proxified object that was moved around), 
+            we shouldn't revoke it, because even though it was removed from path1, it is indeed used in path2.
+            And we know that because we mark moved proxies with `inherited` flag when we move them
+
+            it is a good idea to remove this flag if we come across it here, in deleteProperty trap.
+            We DO want to revoke the proxy if it was removed again.
+          */
+          revokableProxyInstance.inherited = false;
+        } else {
+          instance.parenthoodMap.delete(revokableProxyInstance.originalObject);
+          instance.disableTrapsForProxy(revokableProxyInstance);
+          instance.proxifiedObjectsMap.delete(target[key]);
+        }
+      }
+    }
+    return Reflect.deleteProperty(target, key);
+  }
   /**
-   * A helper function that calls Reflect.set.
-   * It is utilized to re-populate path history map after every `Reflect.set` call.
-   * @param {JSONPatcherProxy} instance JSONPatcherProxy instance
-   * @param {Object} target target object
-   * @param {string} key affected property name 
-   * @param {any} newValue the new set value
+   * Walk up the parenthood tree to get the path
+   * @param {JSONPatcherProxy} instance 
+   * @param {Object} obj the object you need to find its path
    */
-  function ownReflectSet(instance, target, key, newValue) {
-    const result = Reflect.set(target, key, newValue);
-    /* we traverse the new (post-apply) object and update proxies paths accordingly */
-    instance._resetCachedProxiesPaths(instance.cachedProxy, '');
-    return result;
+  function findObjectPath(instance, obj) {
+    var pathComponents = [];
+    var parentAndPath = instance.parenthoodMap.get(obj);
+    while (parentAndPath && parentAndPath.path) {
+      // because we're walking up-tree, we need to use the array as a stack
+      pathComponents.unshift(parentAndPath.path);
+      parentAndPath = instance.parenthoodMap.get(parentAndPath.parent);
+    }
+    if (pathComponents.length) {
+      const path = pathComponents.join('/');
+      return '/' + path;
+    }
+    return '';
+  }
+  /* pre-define resume and pause functions to enhance constructors performance */
+  function resume() {
+    this.defaultCallback = operation => {
+      this.isRecording && this.patches.push(operation);
+      this.userCallback && this.userCallback(operation);
+    };
+    this.isObserving = true;
+  }
+  function pause() {
+    this.defaultCallback = () => {};
+    this.isObserving = false;
   }
   /**
     * Creates an instance of JSONPatcherProxy around your object of interest `root`. 
@@ -33,7 +194,7 @@ const JSONPatcherProxy = (function() {
     this.isProxifyingTreeNow = false;
     this.isObserving = false;
     this.proxifiedObjectsMap = new Map();
-    this.objectsPathsMap = new Map();
+    this.parenthoodMap = new Map();
     // default to true
     if (typeof showDetachedWarning !== 'boolean') {
       showDetachedWarning = true;
@@ -48,26 +209,17 @@ const JSONPatcherProxy = (function() {
      * @memberof JSONPatcherProxy
      * Restores callback back to the original one provided to `observe`.
      */
-    this.resume = () => {
-      this.defaultCallback = operation => {
-        this.isRecording && this.patches.push(operation);
-        this.userCallback && this.userCallback(operation);
-      };
-      this.isObserving = true;
-    };
+    this.resume = resume.bind(this);
     /**
      * @memberof JSONPatcherProxy
      * Replaces your callback with a noop function.
      */
-    this.pause = () => {
-      this.defaultCallback = () => {};
-      this.isObserving = false;
-    };
+    this.pause = pause.bind(this);
   }
   /**
   * Deep clones your object and returns a new object.
   */
-  JSONPatcherProxy.deepClone = function(obj) {
+  function deepClone(obj) {
     switch (typeof obj) {
       case 'object':
         return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5
@@ -76,250 +228,57 @@ const JSONPatcherProxy = (function() {
       default:
         return obj; //no need to clone primitives
     }
-  };
-  JSONPatcherProxy.escapePathComponent = function(str) {
-    if (str.indexOf('/') === -1 && str.indexOf('~') === -1) return str;
-    return str.replace(/~/g, '~0').replace(/\//g, '~1');
-  };
-  /**
-    * A helper function that retrieves the object path from object paths map. 
-    * And if it failed to find it, it sets it for future retrieval.
-    * @param {Object} target the object that you need its path
-    * @param {String} string the path used when object is not found in object-path cache
-  */
-  JSONPatcherProxy.prototype.getOrSetObjectPath = function(target, path) {
-    const cachedPath = this.objectsPathsMap.get(target);
-    if (cachedPath) {
-      return cachedPath;
-    } else {
-      this.objectsPathsMap.set(target, path);
-      return path;
-    }
-  };
+  }
+  JSONPatcherProxy.deepClone = deepClone;
 
-  JSONPatcherProxy.prototype.generateProxyAtPath = function(obj, path) {
+  function escapePathComponent(str) {
+    if (str.indexOf('/') == -1 && str.indexOf('~') == -1) return str;
+    return str.replace(/~/g, '~0').replace(/\//g, '~1');
+  }
+  JSONPatcherProxy.escapePathComponent = escapePathComponent;
+
+  JSONPatcherProxy.prototype.generateProxyAtPath = function(parent, obj, path) {
     if (!obj) {
       return obj;
     }
     const instance = this;
     const traps = {
-      get: function(target, propKey, newValue) {
-        if (propKey.toString() === '_isProxified') {
-          return true; //to distinguish proxies
-        }
-        return Reflect.get(target, propKey, newValue);
-      },
-      set: function(target, key, newValue) {
-        /* each proxified object has its path cached, we need to use that instead of `path` variable
-        because at one point in the future, paths might change and we will simply update our cache instead of 
-        proxifying again.  */
-
-        var destinationPropKey =
-          instance.getOrSetObjectPath(target, path) +
-          '/' +
-          JSONPatcherProxy.escapePathComponent(key);
-
-        /* in case the set value is already proxified by a different instance of JSONPatcherProxy */
-        if (
-          newValue &&
-          newValue._isProxified &&
-          !instance.proxifiedObjectsMap.has(newValue)
-        ) {
-          newValue = JSONPatcherProxy.deepClone(newValue);
-        } else {
-          /* mark already proxified values as inherited.
-          rationale: proxy.obj1 = proxy.obj2
-          will emit
-          {op: replace, path: '/obj1', value: obj2}
-          {op: remove, path: '/obj2'}
-          
-          by default, the second operation would revoke the proxy, an this renders obj1 revoked.
-          That's why we need to remember the proxies that are inherited.
-          */
-
-          const revokableInstance = instance.proxifiedObjectsMap.get(newValue);
-
-          /*
-          Why do we need to check instance.isProxifyingTreeNow?
-
-          We need to make sure we mark revokables as inherited ONLY when we're observing,
-          because throughout the first proxification, a sub-object is proxified and then assigned to 
-          its parent object. This assignment of a pre-proxified object can fool us into thinking
-          that it's a proxified object moved around, while in fact it's the first assignment ever. 
-
-          Checking isProxifyingTreeNow ensures this is not happening in the first proxification, 
-          but in fact is is a proxified object moved around the tree
-          */
-          if (revokableInstance && !instance.isProxifyingTreeNow) {
-            revokableInstance.inherited = true;
-          }
-        }
-
-        // if the new value is an object, make sure to watch it
-        if (
-          newValue &&
-          typeof newValue === 'object' &&
-          newValue._isProxified !== true
-        ) {
-          newValue = instance._proxifyObjectTreeRecursively(
-            newValue,
-            destinationPropKey
-          );
-        }
-        if (typeof newValue === 'undefined') {
-          if (target.hasOwnProperty(key)) {
-            // when array element is set to `undefined`, should generate replace to `null`
-            if (Array.isArray(target)) {
-              //undefined array elements are JSON.stringified to `null`
-              instance.defaultCallback({
-                op: 'replace',
-                path: destinationPropKey,
-                value: null
-              });
-            } else {
-              instance.defaultCallback({
-                op: 'remove',
-                path: destinationPropKey
-              });
-            }
-            return ownReflectSet(instance, target, key, newValue);
-          } else if (!Array.isArray(target)) {
-            return ownReflectSet(instance, target, key, newValue);
-          }
-        }
-        if (Array.isArray(target) && !Number.isInteger(+key.toString())) {
-          return ownReflectSet(instance, target, key, newValue);
-        }
-        if (target.hasOwnProperty(key)) {
-          if (typeof target[key] === 'undefined') {
-            if (Array.isArray(target)) {
-              instance.defaultCallback({
-                op: 'replace',
-                path: destinationPropKey,
-                value: newValue
-              });
-            } else {
-              instance.defaultCallback({
-                op: 'add',
-                path: destinationPropKey,
-                value: newValue
-              });
-            }
-            return ownReflectSet(instance, target, key, newValue);
-          } else {
-            instance.defaultCallback({
-              op: 'replace',
-              path: destinationPropKey,
-              value: newValue
-            });
-            return ownReflectSet(instance, target, key, newValue);
-          }
-        } else {
-          instance.defaultCallback({
-            op: 'add',
-            path: destinationPropKey,
-            value: newValue
-          });
-          return ownReflectSet(instance, target, key, newValue);
-        }
-      }, 
-      deleteProperty: function(target, key) {
-        if (typeof target[key] !== 'undefined') {
-          instance.defaultCallback({
-            op: 'remove',
-            path:
-              path + '/' + JSONPatcherProxy.escapePathComponent(key.toString())
-          });
-          const revokableProxyInstance = instance.proxifiedObjectsMap.get(
-            target[key]
-          );
-
-          if (revokableProxyInstance) {
-            if (revokableProxyInstance.inherited) {
-              /* this is an inherited proxy (an already proxified object that was moved around), 
-              we shouldn't revoke it, because even though it was removed from path1, it is indeed used in path2.
-              And we know that because we mark moved proxies with `inherited` flag when we move them
-              
-              it is a good idea to remove this flag if we come across it here, in deleteProperty trap.
-              We DO want to revoke the proxy if it was removed again.
-              */
-
-              revokableProxyInstance.inherited = false;
-            } else {
-              instance.objectsPathsMap.delete(
-                revokableProxyInstance.originalObject
-              );
-              instance.disableTrapsForProxy(revokableProxyInstance);
-              instance.proxifiedObjectsMap.delete(target[key]);
-            }
-          }
-        }
-        const result = Reflect.deleteProperty(target, key);
-        /* we need the Reflection to occur before we map paths to their object */
-        instance._resetCachedProxiesPaths(instance.cachedProxy, '');
-        return result;
-      }
+      set: (target, key, value, receiver) =>
+        setTrap(instance, target, key, value, receiver),
+      deleteProperty: (target, key) => deleteTrap(instance, target, key)
     };
     const revocableInstance = Proxy.revocable(obj, traps);
     // cache traps object to disable them later.
     revocableInstance.trapsInstance = traps;
     revocableInstance.originalObject = obj;
+
+    /* keeping track of object's parent and path */    
+    this.parenthoodMap.set(obj, { parent, path });
+
     /* keeping track of all the proxies to be able to revoke them later */
     this.proxifiedObjectsMap.set(revocableInstance.proxy, revocableInstance);
     return revocableInstance.proxy;
   };
-  //grab tree's leaves one by one, encapsulate them into a proxy and return
+  // grab tree's leaves one by one, encapsulate them into a proxy and return
   JSONPatcherProxy.prototype._proxifyObjectTreeRecursively = function(
+    parent,
     root,
     path
   ) {
     for (let key in root) {
       if (root.hasOwnProperty(key)) {
-        if (typeof root[key] === 'object') {
-          const destinationPropKey =
-            path + '/' + JSONPatcherProxy.escapePathComponent(key);
-          root[key] = this.generateProxyAtPath(root[key], destinationPropKey);
-          this._proxifyObjectTreeRecursively(root[key], destinationPropKey);
+        if (root[key] instanceof Object) {
+          root[key] = this._proxifyObjectTreeRecursively(
+            root,
+            root[key],
+            escapePathComponent(key)
+          );
         }
       }
     }
-    return this.generateProxyAtPath(root, path);
+    return this.generateProxyAtPath(parent, root, path);
   };
-  /** 
-    A function that recursively traverses the proxy tree and caches all its proxy-object-children in a map
-    @param {Proxy} root the proxy object
-  */
-  JSONPatcherProxy.prototype._resetCachedProxiesPaths = function(root, path) {
-    /* deleting array elements could render other array elements paths incorrect, 
-    this function fixes all incorrect paths efficiently */
-    for (let key in root) {
-      if (!root.hasOwnProperty(key)) continue;
-      const subObject = root[key];
-      if (subObject && subObject._isProxified) {
-        const destinationPropKey =
-          path + '/' + JSONPatcherProxy.escapePathComponent(key);
-
-        // get the proxy instance (an instance is {proxy, originalObject})
-        var revokableProxyInstance = this.proxifiedObjectsMap.get(subObject);
-        if (revokableProxyInstance) {
-          // get the un-proxified originalObject, we need because `set` trap passes the original object as target
-          const originalObject = revokableProxyInstance.originalObject;
-          // update its path
-          this.objectsPathsMap.set(originalObject, destinationPropKey);
-        }
-        /* Even though we didn't find the proxy in the proxies-cache,
-         We need to continue updating its descendants' paths,
-         because we might come at this point in recursive calls inside `set` trap.
-         Because we cache the proxy (revokableInstance) to proxies map only **after** the revokableInstance is created.
-         And `set` trap can call this function before revokableInstance is created.
-         This means we can come across totally valid proxies that are not cached in the our cache.
-         We continue traversing them because we know 100% they're proxies (they have _isProxified = true).
-         */
-        this._resetCachedProxiesPaths(subObject, destinationPropKey);
-      }
-    }
-  };
-  //this function is for aesthetic purposes
+  // this function is for aesthetic purposes
   JSONPatcherProxy.prototype.proxifyObjectTree = function(root) {
     /*
     while proxyifying object tree,
@@ -330,7 +289,11 @@ const JSONPatcherProxy = (function() {
     */
     this.pause();
     this.isProxifyingTreeNow = true;
-    const proxifiedObject = this._proxifyObjectTreeRecursively(root, '');
+    const proxifiedObject = this._proxifyObjectTreeRecursively(
+      undefined,
+      root,
+      ''
+    );
     /* OK you can record now */
     this.isProxifyingTreeNow = false;
     this.resume();
@@ -385,7 +348,7 @@ const JSONPatcherProxy = (function() {
       throw new Error('You need to either record changes or pass a callback');
     }
     this.isRecording = record;
-    if (callback) this.userCallback = callback;
+    this.userCallback = callback;
     /*
     I moved it here to remove it from `unobserve`,
     this will also make the constructor faster, why initiate
@@ -393,7 +356,6 @@ const JSONPatcherProxy = (function() {
     They might need to use only a callback.
     */
     if (record) this.patches = [];
-    this.originalObject = JSONPatcherProxy.deepClone(this.originalObject);
     this.cachedProxy = this.proxifyObjectTree(this.originalObject);
     return this.cachedProxy;
   };

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -48,7 +48,13 @@ const JSONPatcherProxy = (function() {
     }
     return '';
   }
-
+  /**
+   * The proxy setter trap, this function is used for all proxies and is pre-defined outside for better performance.
+   * @param {JSONPatcherProxy} instance JSONPatcherProxy instance
+   * @param {Object} target the affected object
+   * @param {String} key the effect property's name
+   * @param {Any} newValue the value being set
+   */
   function setTrap(instance, target, key, newValue) {
     const parentPath = findObjectPath(instance, target);
 
@@ -116,6 +122,12 @@ const JSONPatcherProxy = (function() {
             path: destinationPropKey
           });
         }
+        const oldValue = instance.proxifiedObjectsMap.get(target[key]);
+        // was tje deleted a proxified object?
+        if(oldValue) { 
+          instance.parenthoodMap.delete(target[key]);
+          instance.proxifiedObjectsMap.delete(oldValue);
+        }
         return Reflect.set(target, key, newValue);
       } else if (!Array.isArray(target)) {
         return Reflect.set(target, key, newValue);
@@ -157,6 +169,12 @@ const JSONPatcherProxy = (function() {
       return Reflect.set(target, key, newValue);
     }
   }
+  /**
+   * 
+   * @param {JSONPatcherProxy} instance JSONPatcherProxy instance
+   * @param {Object} target the effected object
+   * @param {String} key the effected property's name
+   */
   function deleteTrap(instance, target, key) {
     if (typeof target[key] !== 'undefined') {
       const parentPath = findObjectPath(instance, target);

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -206,7 +206,7 @@ const JSONPatcherProxy = (function() {
   /**
     * Creates an instance of JSONPatcherProxy around your object of interest `root`. 
     * @param {Object|Array} root - the object you want to wrap
-    * @param {Boolean} [showDetachedWarning] - whether to log a warning when a detached sub-object is modified @see {@link https://github.com/Palindrom/JSONPatcherProxy#detached-objects} 
+    * @param {Boolean} [showDetachedWarning = true] - whether to log a warning when a detached sub-object is modified @see {@link https://github.com/Palindrom/JSONPatcherProxy#detached-objects} 
     * @returns {JSONPatcherProxy}
     * @constructor
     */

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,7 @@
     <script src="lib/jasmine-2.5.0/jasmine-html.js"></script>
     <!-- <script src="lib/jasmine-2.5.0/boot.js"></script> -->
     <script src="lib/jasmine-custom-boot.js"></script>
-    <script src="https://rawgit.com/Starcounter-Jack/JSON-Patch/master/dist/fast-json-patch.min.js"></script>
+    <script src="https://rawgit.com/Starcounter-Jack/JSON-Patch/master/dist/fast-json-patch.js"></script>
 
     <!-- include Benchmark.js -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -1,91 +1,231 @@
-var obj, obj2, patches;
+var obj, obj2;
+
 if (typeof window === 'undefined') {
-    var jsdom = require("jsdom").jsdom;
-    var doc = jsdom(undefined, undefined);
-    global.window = doc.defaultView;
-    global.document = doc.defaultView.document;
+  var jsdom = require('jsdom').jsdom;
+  var doc = jsdom(undefined, undefined);
+  global.window = doc.defaultView;
+  global.document = doc.defaultView.document;
 }
 
 if (typeof jsonpatch === 'undefined') {
-    jsonpatch = require('fast-json-patch');
+  jsonpatch = require('fast-json-patch');
 }
 
 if (typeof JSONPatcherProxy === 'undefined') {
-    JSONPatcherProxy = require('../../dist/jsonpatcherproxy.js');
+  JSONPatcherProxy = require('../../src/jsonpatcherproxy.js');
 }
 
 if (typeof Benchmark === 'undefined') {
-    var Benchmark = require('benchmark');
-    var benchmarkResultsToConsole = require('./../helpers/benchmarkReporter.js').benchmarkResultsToConsole;
+  var Benchmark = require('benchmark');
+  var benchmarkResultsToConsole = require('./../helpers/benchmarkReporter.js')
+    .benchmarkResultsToConsole;
 }
 
-console.log("Benchmark: Proxy");
+var suite = new Benchmark.Suite();
 
-var suite = new Benchmark.Suite;
-suite.add('generate operation', function() {
+suite.add('jsonpatcherproxy generate operation', function() {
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    phoneNumbers: [
+      {
+        number: '12345'
+      },
+      {
+        number: '45353'
+      }
+    ]
+  };
 
-    var obj = {
-        firstName: "Albert",
-        lastName: "Einstein",
-        phoneNumbers: [{
-            number: "12345"
-        }, {
-            number: "45353"
-        }]
-    };
+  var jsonPatcherProxy = new JSONPatcherProxy(obj);
+  var observedObj = jsonPatcherProxy.observe(true);
 
-    var jsonPatcherProxy = new JSONPatcherProxy(obj);
-    var observedObj = jsonPatcherProxy.observe(true);
+  var patches = jsonPatcherProxy.generate();
 
-    patches = jsonPatcherProxy.generate();    
-
-    observedObj.firstName = "Joachim";
-    observedObj.lastName = "Wester";
-    observedObj.phoneNumbers[0].number = "123";
-    observedObj.phoneNumbers[1].number = "456";
-
-    patches = jsonPatcherProxy.generate();
-    obj2 = {
-        firstName: "Albert",
-        lastName: "Einstein",
-        phoneNumbers: [{
-            number: "12345"
-        }, {
-            number: "45353"
-        }]
-    };
-
-    jsonpatch.apply(obj2, patches);
+  observedObj.firstName = 'Joachim';
+  observedObj.lastName = 'Wester';
+  observedObj.phoneNumbers[0].number = '123';
+  observedObj.phoneNumbers[1].number = '456';
 });
-suite.add('compare operation', function() {
-    var obj = {
-        firstName: "Albert",
-        lastName: "Einstein",
-        phoneNumbers: [{
-            number: "12345"
-        }, {
-            number: "45353"
-        }]
-    };
-    var obj2 = {
-        firstName: "Joachim",
-        lastName: "Wester",
-        mobileNumbers: [{
-            number: "12345"
-        }, {
-            number: "45353"
-        }]
-    };
+suite.add('jsonpatch generate operation', function() {
+  var observedObj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    phoneNumbers: [
+      {
+        number: '12345'
+      },
+      {
+        number: '45353'
+      }
+    ]
+  };
+  var observer = jsonpatch.observe(observedObj);
 
-    var patches = jsonpatch.compare(obj, obj2);
+  observedObj.firstName = 'Joachim';
+  observedObj.lastName = 'Wester';
+  observedObj.phoneNumbers[0].number = '123';
+  observedObj.phoneNumbers[1].number = '456';
+
+  jsonpatch.generate(observer);
+});
+
+
+
+
+
+suite.add('jsonpatcherproxy mutation - huge object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+
+  for (var i = 0; i < 100; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+  var jsonPatcherProxy = new JSONPatcherProxy(obj);
+  var observedObj = jsonPatcherProxy.observe(true);
+
+  observedObj.cars[50].name = 'Toyota'
+});
+
+suite.add('jsonpatch mutation - huge object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+
+  for (var i = 0; i < 100; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+
+  var observer = jsonpatch.observe(obj);
+
+  obj.cars[50].name = 'Toyota';
+
+  jsonpatch.generate(observer);
+});
+
+suite.add('jsonpatcherproxy generate operation - huge object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+
+  for (var i = 0; i < 100; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+  var jsonPatcherProxy = new JSONPatcherProxy(obj);
+  var observedObj = jsonPatcherProxy.observe(true);
+
+  observedObj.cars.shift();
+});
+
+suite.add('jsonpatch generate operation - huge object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+
+  for (var i = 0; i < 100; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+
+  var observer = jsonpatch.observe(obj);
+
+  obj.cars.shift();
+
+  jsonpatch.generate(observer);
+});
+
+suite.add('PROXIFY big object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+  for (var i = 0; i < 50; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+
+  var jsonPatcherProxy = new JSONPatcherProxy(obj);
+
+  var observedObj = jsonPatcherProxy.observe(true);
+  observedObj.a = 1;
+});
+
+suite.add('DIRTY-OBSERVE big object', function() {
+  var singleCar = { name: 'Tesla', speed: 100 };
+
+  var obj = {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    cars: []
+  };
+  for (var i = 0; i < 50; i++) {
+    var copy = JSONPatcherProxy.deepClone(singleCar);
+    var temp = copy;
+    for (var j = 0; j < 5; j++) {
+      temp.temp = JSONPatcherProxy.deepClone(singleCar);
+      temp = temp.temp;
+    }
+    obj.cars.push(copy);
+  }
+  var observer = jsonpatch.observe(obj);
+  obj.a = 1;
+  jsonpatch.generate(observer);
 });
 
 // if we are in the browser with benchmark < 2.1.2
-if(typeof benchmarkReporter !== 'undefined'){
-    benchmarkReporter(suite);
+if (typeof benchmarkReporter !== 'undefined') {
+  benchmarkReporter(suite);
 } else {
-    suite.on('complete', function () {
-        benchmarkResultsToConsole(suite);
-    });
-    suite.run();
+  suite.on('complete', function() {
+    benchmarkResultsToConsole(suite);
+  });
+  suite.run();
 }


### PR DESCRIPTION
The issue (https://github.com/Palindrom/JSONPatcherProxy/issues/16) arose with modifying a big array. JSONPatcherProxy traversed the whole tree N^3 times for any mutation that changes the array's length! For an array of N=100, this is 1000000 times of intensive iterations. 

I re-designed the whole path tracking method and now JSONPatcherProxy is 65x (6591%) faster when it comes to that issue.

Proxification recursion was very bad and was actually wrong, now it's much cleaner and 586% faster than before. 

Modifying a realistic (size-wise) object (less than 50 children) is much faster than jsonpatch. It's 449% faster than jsonpatch and 281% faster than JSONPatcherProxy before.

Here is a chart for everything:
![image](https://user-images.githubusercontent.com/17054134/30154777-3a67f738-93bb-11e7-9ea9-08b9e58e9bca.png)



Numbers before: https://travis-ci.org/Palindrom/JSONPatcherProxy/builds/272802078
Numbers after: https://travis-ci.org/Palindrom/JSONPatcherProxy/builds/272793569


## How this works:

It's much simpler than before. Now whenever an object is proxified I record its
- `parent`
- `path`

Note that the `parent` was also proxified at one point of time, so we know its path, and so on.

### Now, when an object is mutated, in a way that doesn't change its hierarchy (`arr[1].name = 1`), we:
- Go to our (`obj => {parent, path}`) map.
- Find the object itself, collect its `path` (basically its name, as in its `key` within its parent object). Collect its `parent` object, too.
- Now that we have the `parent`, we look up its `name` too. And we do this until we arrive at `root`. We `join` these keys with `/` delimiter.

This is very cheap because it happens DEPTH times. Independent of array size. A mega elements wouldn't matter.

### When a change that changes hierarchy occurs:

This happens when we remove say the first element of a big array. All other elements will need their paths updated. (`arr[1]` is now `arr[0]`). In this case, the complexity is O(N), and there is no sync way out of it. `array.shift()` doesn't remove the first item, it literally shifts the whole array. When the array is being shifted, element by element (this has nothing to do with our impl) we update each child's name (`key`) to the new one with an O(1) operation. O(N) * O(1) = O(N).


