### PR TITLE
Reflect before invoking the callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_script:
   - 'export PATH=$PWD/node_modules/.bin:$PATH'
 node_js: 6
 script:
-  - xvfb-run npm test
-  - xvfb-run npm run bench
+  - npm run test
+  - npm run bench

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -35,8 +35,8 @@ const JSONPatcherProxy = (function() {
    * @param {Object} obj the object you need to find its path
    */
   function findObjectPath(instance, obj) {
-    var pathComponents = [];
-    var parentAndPath = instance.parenthoodMap.get(obj);
+    const pathComponents = [];
+    let parentAndPath = instance.parenthoodMap.get(obj);
     while (parentAndPath && parentAndPath.path) {
       // because we're walking up-tree, we need to use the array as a stack
       pathComponents.unshift(parentAndPath.path);
@@ -59,17 +59,17 @@ const JSONPatcherProxy = (function() {
   function setTrap(instance, target, key, newValue) {
     const parentPath = findObjectPath(instance, target);
 
-    var destinationPropKey = parentPath + '/' + escapePathComponent(key);
-    {
-      if (instance.proxifiedObjectsMap.has(newValue)) {
-        var newValueOriginalObject = instance.proxifiedObjectsMap.get(newValue);
+    const destinationPropKey = parentPath + '/' + escapePathComponent(key);
 
-        instance.parenthoodMap.set(newValueOriginalObject.originalObject, {
-          parent: target,
-          path: key
-        });
-      }
-      /*
+    if (instance.proxifiedObjectsMap.has(newValue)) {
+      const newValueOriginalObject = instance.proxifiedObjectsMap.get(newValue);
+
+      instance.parenthoodMap.set(newValueOriginalObject.originalObject, {
+        parent: target,
+        path: key
+      });
+    }
+    /*
         mark already proxified values as inherited.
         rationale: proxy.arr.shift()
         will emit
@@ -79,22 +79,22 @@ const JSONPatcherProxy = (function() {
         by default, the second operation would revoke the proxy, and this renders arr revoked.
         That's why we need to remember the proxies that are inherited.
       */
-      const revokableInstance = instance.proxifiedObjectsMap.get(newValue);
-      /*
-          Why do we need to check instance.isProxifyingTreeNow?
+    const revokableInstance = instance.proxifiedObjectsMap.get(newValue);
+    /*
+    Why do we need to check instance.isProxifyingTreeNow?
 
-          We need to make sure we mark revokables as inherited ONLY when we're observing,
-          because throughout the first proxification, a sub-object is proxified and then assigned to 
-          its parent object. This assignment of a pre-proxified object can fool us into thinking
-          that it's a proxified object moved around, while in fact it's the first assignment ever. 
+    We need to make sure we mark revokables as inherited ONLY when we're observing,
+    because throughout the first proxification, a sub-object is proxified and then assigned to 
+    its parent object. This assignment of a pre-proxified object can fool us into thinking
+    that it's a proxified object moved around, while in fact it's the first assignment ever. 
 
-          Checking isProxifyingTreeNow ensures this is not happening in the first proxification, 
-          but in fact is is a proxified object moved around the tree
-          */
-      if (revokableInstance && !instance.isProxifyingTreeNow) {
-        revokableInstance.inherited = true;
-      }
+    Checking isProxifyingTreeNow ensures this is not happening in the first proxification, 
+    but in fact is is a proxified object moved around the tree
+    */
+    if (revokableInstance && !instance.isProxifyingTreeNow) {
+      revokableInstance.inherited = true;
     }
+
     // if the new value is an object, make sure to watch it
     if (
       newValue &&
@@ -108,9 +108,11 @@ const JSONPatcherProxy = (function() {
       newValue = instance._proxifyObjectTreeRecursively(target, newValue, key);
     }
     if (typeof newValue == 'undefined') {
+      let reflectionResult;
       if (target.hasOwnProperty(key)) {
         // when array element is set to `undefined`, should generate replace to `null`
         if (Array.isArray(target)) {
+          reflectionResult = Reflect.set(target, key, newValue);
           //undefined array elements are JSON.stringified to `null`
           instance.defaultCallback({
             op: 'replace',
@@ -118,6 +120,7 @@ const JSONPatcherProxy = (function() {
             value: null
           });
         } else {
+          reflectionResult = Reflect.set(target, key, newValue);
           instance.defaultCallback({
             op: 'remove',
             path: destinationPropKey
@@ -125,12 +128,12 @@ const JSONPatcherProxy = (function() {
         }
         const oldValue = instance.proxifiedObjectsMap.get(target[key]);
         // was the deleted a proxified object?
-        if(oldValue) { 
+        if (oldValue) {
           instance.parenthoodMap.delete(target[key]);
           instance.disableTrapsForProxy(oldValue);
           instance.proxifiedObjectsMap.delete(oldValue);
         }
-        return Reflect.set(target, key, newValue);
+        return reflectionResult;
       } else if (!Array.isArray(target)) {
         return Reflect.set(target, key, newValue);
       }
@@ -139,37 +142,42 @@ const JSONPatcherProxy = (function() {
     if (Array.isArray(target) && !Number.isInteger(+key.toString())) {
       return Reflect.set(target, key, newValue);
     }
+    let reflectionResult;
     if (target.hasOwnProperty(key)) {
       if (typeof target[key] == 'undefined') {
         if (Array.isArray(target)) {
+          reflectionResult = Reflect.set(target, key, newValue);
           instance.defaultCallback({
             op: 'replace',
             path: destinationPropKey,
             value: newValue
           });
         } else {
+          reflectionResult = Reflect.set(target, key, newValue);
           instance.defaultCallback({
             op: 'add',
             path: destinationPropKey,
             value: newValue
           });
         }
-        return Reflect.set(target, key, newValue);
+        return reflectionResult;
       } else {
+        reflectionResult = Reflect.set(target, key, newValue);
         instance.defaultCallback({
           op: 'replace',
           path: destinationPropKey,
           value: newValue
         });
-        return Reflect.set(target, key, newValue);
+        return reflectionResult;
       }
     } else {
+      reflectionResult = Reflect.set(target, key, newValue);
       instance.defaultCallback({
         op: 'add',
         path: destinationPropKey,
         value: newValue
       });
-      return Reflect.set(target, key, newValue);
+      return reflectionResult;
     }
   }
   /**
@@ -182,13 +190,8 @@ const JSONPatcherProxy = (function() {
   function deleteTrap(instance, target, key) {
     if (typeof target[key] !== 'undefined') {
       const parentPath = findObjectPath(instance, target);
-
       const destinationPropKey = parentPath + '/' + escapePathComponent(key);
 
-      instance.defaultCallback({
-        op: 'remove',
-        path: destinationPropKey
-      });
       const revokableProxyInstance = instance.proxifiedObjectsMap.get(
         target[key]
       );
@@ -197,7 +200,7 @@ const JSONPatcherProxy = (function() {
         if (revokableProxyInstance.inherited) {
           /*
             this is an inherited proxy (an already proxified object that was moved around), 
-            we shouldn't revoke it, because even though it was removed from path1, it is indeed used in path2.
+            we shouldn't revoke it, because even though it was removed from path1, it is still used in path2.
             And we know that because we mark moved proxies with `inherited` flag when we move them
 
             it is a good idea to remove this flag if we come across it here, in deleteProperty trap.
@@ -210,8 +213,15 @@ const JSONPatcherProxy = (function() {
           instance.proxifiedObjectsMap.delete(target[key]);
         }
       }
+      const reflectionResult = Reflect.deleteProperty(target, key);
+
+      instance.defaultCallback({
+        op: 'remove',
+        path: destinationPropKey
+      });
+
+      return reflectionResult;
     }
-    return Reflect.deleteProperty(target, key);
   }
   /* pre-define resume and pause functions to enhance constructors performance */
   function resume() {
@@ -263,11 +273,10 @@ const JSONPatcherProxy = (function() {
     if (!obj) {
       return obj;
     }
-    const instance = this;
     const traps = {
       set: (target, key, value, receiver) =>
-        setTrap(instance, target, key, value, receiver),
-      deleteProperty: (target, key) => deleteTrap(instance, target, key)
+        setTrap(this, target, key, value, receiver),
+      deleteProperty: (target, key) => deleteTrap(this, target, key)
     };
     const revocableInstance = Proxy.revocable(obj, traps);
     // cache traps object to disable them later.

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -1087,11 +1087,11 @@ describe('proxy', function() {
               firstName: 'Albert'
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.lastName).toReallyEqual('Newton');
             });
+
             observedObj.lastName = 'Newton';
           });
 
@@ -1100,11 +1100,11 @@ describe('proxy', function() {
               firstName: 'Albert'
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.firstName).toReallyEqual('Joachim');
             });
+
             observedObj.firstName = 'Joachim';
           });
 
@@ -1113,11 +1113,11 @@ describe('proxy', function() {
               firstName: 'Albert'
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.firstName).toReallyEqual(undefined);
             });
+
             delete observedObj.firstName;
           });
         });
@@ -1128,11 +1128,11 @@ describe('proxy', function() {
               numbers: [1, 2, 3]
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.numbers[3]).toReallyEqual(4);
             });
+
             observedObj.numbers.push(4);
           });
 
@@ -1142,11 +1142,11 @@ describe('proxy', function() {
               numbers: [1, 2, 3]
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.numbers[0]).toReallyEqual(100);
             });
+            
             observedObj.numbers[0] = 100;
           });
 
@@ -1156,9 +1156,8 @@ describe('proxy', function() {
               numbers: [1, 2, 3]
             };
             var jsonPatcherProxy = new JSONPatcherProxy(obj);
-            var observedObj = jsonPatcherProxy.observe(true);
 
-            jsonPatcherProxy.observe(true, function(_patches) {
+            var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.numbers[0]).toReallyEqual(2);
             });
 


### PR DESCRIPTION
Fixes: https://github.com/Palindrom/JSONPatcherProxy/issues/21

@warpech can you review please? 

Reviewing while ignoring the whitespace saves you a minute or two (https://github.com/Palindrom/JSONPatcherProxy/compare/Reflect-earlier?expand=1&w=1)