### PR TITLE
Removed parameter initializer in type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare class JSONPatcherProxy {
     * @returns {JSONPatcherProxy}
     * @constructor
     */
-    constructor(root: any, showDetachedWarning: boolean = true);
+    constructor(root: any, showDetachedWarning?: boolean);
     /**
      * Proxifies the object that was passed in the constructor and returns a proxified mirror of it.
      * @param {Boolean} record - whether to record object changes to a later-retrievable patches array.


### PR DESCRIPTION
Loading the library in a TypeScript application resulted in this error:

    ERROR in node_modules/jsonpatcherproxy/index.d.ts(43,28): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

This commit fixes that issue.