### PR TITLE
Optional callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare class JSONPatcherProxy {
      * @param {Boolean} record - whether to record object changes to a later-retrievable patches array.
      * @param {Function} [callback] - this will be synchronously called with every object change with a single `patch` as the only parameter.
      */
-    public observe(record: Boolean, callback: Function): any;
+    public observe(record: Boolean, callback?: Function): any;
     /**
      * If the observed is set to record, it will synchronously return all the patches and empties patches array.
      */


### PR DESCRIPTION
Incidentally includes #29, that one should be merged first.  This PR makes the `callback` argument optional in the type def, since that's how the implementation is.