### PR TITLE
TypeScript Class Generics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@
  */
 
 /** Class representing a JS Object observer  */
-declare class JSONPatcherProxy {
+declare class JSONPatcherProxy<T> {
     /**
     * Deep clones your object and returns a new object.
     */
@@ -40,7 +40,7 @@ declare class JSONPatcherProxy {
     * @returns {JSONPatcherProxy}
     * @constructor
     */
-    constructor(root: any, showDetachedWarning: boolean = true);
+    constructor(root: T, showDetachedWarning: boolean = true);
     /**
      * Proxifies the object that was passed in the constructor and returns a proxified mirror of it.
      * @param {Boolean} record - whether to record object changes to a later-retrievable patches array.
@@ -55,7 +55,7 @@ declare class JSONPatcherProxy {
      * @param {Boolean} record - whether to record object changes to a later-retrievable patches array.
      * @param {Function} [callback] - this will be synchronously called with every object change with a single `patch` as the only parameter.
      */
-    public observe(record: Boolean, callback: Function): any;
+    public observe(record: Boolean, callback: Function): T;
     /**
      * If the observed is set to record, it will synchronously return all the patches and empties patches array.
      */


### PR DESCRIPTION
This change adds a generic type to the proxy class.  This ensures type safety between the root object and the proxy object.