### PR TITLE
Compatibility with external deep proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "webpack",
     "build-watch": "webpack --watch",
     "bench": "node test/spec/proxyBenchmark.js",
+    "bench-compare": "node test/spec/proxyBenchmark.js --compare",
     "test": "jasmine DUPLEX=proxy JASMINE_CONFIG_PATH=test/jasmine.json",
     "test-debug": "node --inspect-brk node_modules/jasmine/bin/jasmine.js DUPLEX=proxy JASMINE_CONFIG_PATH=test/jasmine.json",
     "version": "webpack && git add -A"

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -86,7 +86,11 @@ const JSONPatcherProxy = (function() {
       const subtreeMetadata = newValue[instance._metadataSymbol];
       if (subtreeMetadata) {
         if(subtreeMetadata.parent === tree && subtreeMetadata.keyInParent === key) {
-          //this is the same object that we already proxified, proxified now by someone else. In this case, remain silent
+          /* 
+          This is an object that is already proxified by this instance of JSONPatcherProxy, 
+          which is now being proxified by some external code or simply reassigned at the same place.
+          In this case, remain silent.
+          */
           return Reflect.set(tree, key, newValue);
         }
         subtreeMetadata.parent = tree;

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -85,6 +85,10 @@ const JSONPatcherProxy = (function() {
     if (isObject(newValue)) {
       const subtreeMetadata = newValue[instance._metadataSymbol];
       if (subtreeMetadata) {
+        if(subtreeMetadata.parent === tree && subtreeMetadata.keyInParent === key) {
+          //this is the same object that we already proxified, proxified now by someone else. In this case, remain silent
+          return Reflect.set(tree, key, newValue);
+        }
         subtreeMetadata.parent = tree;
         subtreeMetadata.keyInParent = key;
         /*

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -1,9 +1,23 @@
+/*
+  To run with comparisons:
+  $ npm run bench-compare
+
+  To run without comparisons:
+  $ npm run bench
+  */
+
+let includeComparisons = true;
+
 if (typeof window === 'undefined') {
   const jsdom = require("jsdom");
   const { JSDOM } = jsdom;
   const dom = new JSDOM();
   global.window = dom.window;
   global.document = dom.window.document;
+
+  if (!process.argv.includes("--compare")) {
+    includeComparisons = false;
+  }
 }
 
 if (typeof jsonpatch === 'undefined') {
@@ -59,7 +73,7 @@ function reverseString(str) {
 {
   const suiteName = 'Observe and generate, small object';
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (noop)`, function() {
       const obj = generateBigObjectFixture(1);
       modifyObj(obj);
@@ -76,7 +90,7 @@ function reverseString(str) {
     });
   }
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (fast-json-patch)`, function() {
       const obj = generateBigObjectFixture(1);
       const observer = jsonpatch.observe(obj);
@@ -91,7 +105,7 @@ function reverseString(str) {
 {
   const suiteName = 'Observe and generate';
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (noop)`, function() {
       const obj = generateBigObjectFixture(100);
       modifyObj(obj);
@@ -108,7 +122,7 @@ function reverseString(str) {
     });
   }
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (fast-json-patch)`, function() {
       const obj = generateBigObjectFixture(100);
       const observer = jsonpatch.observe(obj);
@@ -123,7 +137,7 @@ function reverseString(str) {
 {
   const suiteName = 'Primitive mutation';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     
     suite.add(`${suiteName} (noop)`, function() {
@@ -141,7 +155,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
     
@@ -157,7 +171,7 @@ function reverseString(str) {
 {
   const suiteName = 'Complex mutation';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
   
     suite.add(`${suiteName} (noop)`, function() {
@@ -177,7 +191,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
   
@@ -194,7 +208,7 @@ function reverseString(str) {
 {
   const suiteName = 'Serialization';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
   
     suite.add(`${suiteName} (noop)`, function() {
@@ -212,7 +226,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
   

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -1,9 +1,7 @@
-var obj, obj2;
-
 if (typeof window === 'undefined') {
   const jsdom = require("jsdom");
   const { JSDOM } = jsdom;
-  var dom = new JSDOM();
+  const dom = new JSDOM();
   global.window = dom.window;
   global.document = dom.window.document;
 }
@@ -22,10 +20,10 @@ if (typeof Benchmark === 'undefined') {
     .benchmarkResultsToConsole;
 }
 
-var suite = new Benchmark.Suite();
+const suite = new Benchmark.Suite();
 
-suite.add('jsonpatcherproxy generate operation', function() {
-  var obj = {
+function generateDeepObjectFixture() {
+  return {
     firstName: 'Albert',
     lastName: 'Einstein',
     phoneNumbers: [
@@ -36,187 +34,89 @@ suite.add('jsonpatcherproxy generate operation', function() {
         number: '45353'
       }
     ]
-  };
+  }
+}
 
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
+function generateSmallObjectFixture() {
+  return { name: 'Tesla', speed: 100 };
+}
 
-  var patches = jsonPatcherProxy.generate();
-
-  observedObj.firstName = 'Joachim';
-  observedObj.lastName = 'Wester';
-  observedObj.phoneNumbers[0].number = '123';
-  observedObj.phoneNumbers[1].number = '456';
-});
-suite.add('jsonpatch generate operation', function() {
-  var observedObj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    phoneNumbers: [
-      {
-        number: '12345'
-      },
-      {
-        number: '45353'
-      }
-    ]
-  };
-  var observer = jsonpatch.observe(observedObj);
-
-  observedObj.firstName = 'Joachim';
-  observedObj.lastName = 'Wester';
-  observedObj.phoneNumbers[0].number = '123';
-  observedObj.phoneNumbers[1].number = '456';
-
-  jsonpatch.generate(observer);
-});
-
-
-
-
-
-suite.add('jsonpatcherproxy mutation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
+function generateBigObjectFixture(carsSize) {
+  const obj = {
     firstName: 'Albert',
     lastName: 'Einstein',
     cars: []
   };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
+  for (let i = 0; i < carsSize; i++) {
+    let deep = generateSmallObjectFixture();
+    obj.cars.push(deep);
+    for (let j = 0; j < 5; j++) {
+      deep.temp = generateSmallObjectFixture();
+      deep = deep.temp;
     }
-    obj.cars.push(copy);
   }
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
+  return obj;
+}
 
+suite.add('jsonpatcherproxy generate operation', function() {
+  const obj = generateDeepObjectFixture();
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
+  const patches = jsonPatcherProxy.generate();
+  observedObj.firstName = 'Joachim';
+  observedObj.lastName = 'Wester';
+  observedObj.phoneNumbers[0].number = '123';
+  observedObj.phoneNumbers[1].number = '456';
+});
+
+suite.add('jsonpatch generate operation', function() {
+  const obj = generateDeepObjectFixture();
+  const observer = jsonpatch.observe(obj);
+  obj.firstName = 'Joachim';
+  obj.lastName = 'Wester';
+  obj.phoneNumbers[0].number = '123';
+  obj.phoneNumbers[1].number = '456';
+  jsonpatch.generate(observer);
+});
+
+suite.add('jsonpatcherproxy mutation - huge object', function() {
+  const obj = generateBigObjectFixture(100);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.cars[50].name = 'Toyota'
 });
 
 suite.add('jsonpatch mutation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var observer = jsonpatch.observe(obj);
-
+  const obj = generateBigObjectFixture(100);
+  const observer = jsonpatch.observe(obj);
   obj.cars[50].name = 'Toyota';
-
   jsonpatch.generate(observer);
 });
 
 suite.add('jsonpatcherproxy generate operation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
-
+  const obj = generateBigObjectFixture(100);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.cars.shift();
 });
 
 suite.add('jsonpatch generate operation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var observer = jsonpatch.observe(obj);
-
+  const obj = generateBigObjectFixture(100);
+  const observer = jsonpatch.observe(obj);
   obj.cars.shift();
-
   jsonpatch.generate(observer);
 });
 
 suite.add('PROXIFY big object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-  for (var i = 0; i < 50; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-
-  var observedObj = jsonPatcherProxy.observe(true);
+  const obj = generateBigObjectFixture(50);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.a = 1;
 });
 
 suite.add('DIRTY-OBSERVE big object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-  for (var i = 0; i < 50; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-  var observer = jsonpatch.observe(obj);
+  const obj = generateBigObjectFixture(50);
+  const observer = jsonpatch.observe(obj);
   obj.a = 1;
   jsonpatch.generate(observer);
 

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -191,6 +191,39 @@ function reverseString(str) {
 
 /* ============================= */
 
+{
+  const suiteName = 'Serialization';
+
+  {
+    const obj = generateBigObjectFixture(100);
+  
+    suite.add(`${suiteName} (noop)`, function() {
+      JSON.stringify(obj);
+    });
+  }
+
+  {
+    const obj = generateBigObjectFixture(100);
+    const jsonPatcherProxy = new JSONPatcherProxy(obj);
+    const observedObj = jsonPatcherProxy.observe(true);
+  
+    suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
+      JSON.stringify(observedObj);
+    });
+  }
+
+  {
+    const obj = generateBigObjectFixture(100);
+    const observer = jsonpatch.observe(obj);
+  
+    suite.add(`${suiteName} (fast-json-patch)`, function() {
+      JSON.stringify(obj);
+    });
+  }
+}
+
+/* ============================= */
+
 // if we are in the browser with benchmark < 2.1.2
 if (typeof benchmarkReporter !== 'undefined') {
   benchmarkReporter(suite);

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -85,8 +85,8 @@ function reverseString(str) {
       const obj = generateBigObjectFixture(1);
       const jsonPatcherProxy = new JSONPatcherProxy(obj);
       const observedObj = jsonPatcherProxy.observe(true);
-      const patches = jsonPatcherProxy.generate();
       modifyObj(observedObj);
+      jsonPatcherProxy.generate();
     });
   }
   
@@ -117,8 +117,8 @@ function reverseString(str) {
       const obj = generateBigObjectFixture(100);
       const jsonPatcherProxy = new JSONPatcherProxy(obj);
       const observedObj = jsonPatcherProxy.observe(true);
-      const patches = jsonPatcherProxy.generate();
       modifyObj(observedObj);
+      jsonPatcherProxy.generate();
     });
   }
   
@@ -152,6 +152,7 @@ function reverseString(str) {
     
     suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
       observedObj.cars[50].name = reverseString(observedObj.cars[50].name);
+      jsonPatcherProxy.generate();
     });
   }
 
@@ -188,6 +189,7 @@ function reverseString(str) {
     suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
       const item = observedObj.cars.shift();
       observedObj.cars.push(item);
+      jsonPatcherProxy.generate();
     });
   }
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -295,6 +295,27 @@ describe('proxy', function() {
         }
       ]);
     });
+    
+    it('should generate replace (deep object, proxified twice by JSONPatcherProxy)', function() {
+      const obj = generateDeepObjectFixture();
+      const jsonPatcherProxy = new JSONPatcherProxy(obj);
+      let observedObj = jsonPatcherProxy.observe(true);
+      const jsonPatcherProxy2 = new JSONPatcherProxy(observedObj);
+      let observedObj2 = jsonPatcherProxy2.observe(true);
+    
+      observedObj2.phoneNumbers[0].number = '123';
+
+      const patches = jsonPatcherProxy.generate();
+      const patches2 = jsonPatcherProxy2.generate();
+      expect(patches).toReallyEqual([
+        {
+          op: 'replace',
+          path: '/phoneNumbers/0/number',
+          value: '123'
+        }
+      ]);
+      expect(patches).toReallyEqual(patches2);
+    });
 
     it('should generate replace (changes in new array cell, primitive values)', function() {
       var arr = [1];

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -124,7 +124,7 @@ describe('proxy', function() {
       expect(obj2).toReallyEqual(observedObj);
     });
     it('should generate replace (escaped chars)', function() {
-      var obj = {
+      const obj = {
         '/name/first': 'Albert',
         '/name/last': 'Einstein',
         '~phone~/numbers': [
@@ -136,6 +136,7 @@ describe('proxy', function() {
           }
         ]
       };
+      const obj2 = JSON.parse(JSON.stringify(obj));
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -145,19 +146,6 @@ describe('proxy', function() {
       observedObj['~phone~/numbers'][1].number = '456';
 
       var patches = jsonPatcherProxy.generate();
-      var obj2 = {
-        '/name/first': 'Albert',
-        '/name/last': 'Einstein',
-        '~phone~/numbers': [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
       jsonpatch.applyPatch(obj2, patches);
 
       /* iOS and Android */
@@ -278,18 +266,10 @@ describe('proxy', function() {
       /* iOS and Android */
       observedObj = JSONPatcherProxy.deepClone(observedObj);
 
-      expect(observedObj).toReallyEqual({
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '123'
-          },
-          {
-            number: '456'
-          }
-        ]
-      }); //objects should be still the same
+      const obj2 = generateDeepObjectFixture();
+      obj2.phoneNumbers[0].number = '123';
+      obj2.phoneNumbers[1].number = '456';
+      expect(observedObj).toReallyEqual(obj2); //objects should be still the same
     });
 
     it('should generate replace (changes in new array cell, primitive values)', function() {
@@ -416,18 +396,7 @@ describe('proxy', function() {
 
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
       expect(obj2).toEqualInJson(observedObj);
     });
@@ -981,18 +950,10 @@ describe('proxy', function() {
         }
       ]); //first patch should NOT be reported again here
 
-      expect(observedObj).toReallyEqual({
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '123'
-          },
-          {
-            number: '456'
-          }
-        ]
-      });
+      const obj2 = generateDeepObjectFixture();
+      obj2.phoneNumbers[0].number = '123';
+      obj2.phoneNumbers[1].number = '456';
+      expect(observedObj).toReallyEqual(obj2);
     });
 
     describe(

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -24,6 +24,21 @@ function getPatchesUsingCompare(objFactory, objChanger) {
   return jsonpatch.compare(mirror, JSON.parse(JSON.stringify(obj)));
 }
 
+function generateDeepObjectFixture() {
+  return {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    phoneNumbers: [
+      {
+        number: '12345'
+      },
+      {
+        number: '45353'
+      }
+    ]
+  }
+}
+
 var customMatchers = {
   /**
      * This matcher is only needed in Chrome 28 (Chrome 28 cannot successfully compare observed objects immediately after they have been changed. Chrome 30 is unaffected)
@@ -88,18 +103,7 @@ describe('proxy', function() {
 
   describe('generate', function() {
     it('should generate replace', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -111,18 +115,7 @@ describe('proxy', function() {
 
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
 
       /* iOS and Android */
@@ -212,19 +205,7 @@ describe('proxy', function() {
     });
 
     it('should generate replace (double change, shallow object)', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -268,19 +249,7 @@ describe('proxy', function() {
     });
 
     it('should generate replace (double change, deep object)', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -419,14 +388,7 @@ describe('proxy', function() {
       ]);
     });
     it('should generate add', function() {
-      var obj = {
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -438,31 +400,12 @@ describe('proxy', function() {
       });
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          }
-        ]
-      };
-
+      var obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
       expect(obj2).toEqualInJson(observedObj);
     });
     it('should generate remove', function() {
-      var obj = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -489,18 +432,7 @@ describe('proxy', function() {
       expect(obj2).toEqualInJson(observedObj);
     });
     it('should generate remove and disable all traps', function() {
-      var obj = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -937,18 +869,7 @@ describe('proxy', function() {
   describe('callback', function() {
     it('should generate replace', function() {
       var obj2;
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -959,18 +880,7 @@ describe('proxy', function() {
       observedObj.firstName = 'Joachim';
 
       function objChanged(operation) {
-        obj2 = {
-          firstName: 'Albert',
-          lastName: 'Einstein',
-          phoneNumbers: [
-            {
-              number: '12345'
-            },
-            {
-              number: '45353'
-            }
-          ]
-        };
+        obj2 = generateDeepObjectFixture();
         jsonpatch.applyOperation(obj2, operation);
 
         /* iOS and Android */
@@ -984,18 +894,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0;
 
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
 
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
@@ -1051,18 +950,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0;
 
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
 
       var observedObj = jsonPatcherProxy.observe(true);
@@ -1200,18 +1088,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0,
         res;
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+        const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;
@@ -1427,20 +1304,7 @@ describe('proxy', function() {
   describe('pausing and resuming', function() {
     it("shouldn't emit patches when paused", function() {
       var called = 0;
-
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;
@@ -1460,20 +1324,7 @@ describe('proxy', function() {
 
     it('Should re-start emitting patches when paused then resumed', function() {
       var called = 0;
-
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -271,6 +271,30 @@ describe('proxy', function() {
       obj2.phoneNumbers[1].number = '456';
       expect(observedObj).toReallyEqual(obj2); //objects should be still the same
     });
+    
+    it('should generate replace (deep object, proxified)', function() {
+      const obj = generateDeepObjectFixture();
+      const jsonPatcherProxy = new JSONPatcherProxy(obj);
+      let observedObj = jsonPatcherProxy.observe(true);
+    
+      //begin external proxification
+      observedObj = new Proxy(observedObj, {});
+      observedObj.phoneNumbers = new Proxy(observedObj.phoneNumbers, {});
+      observedObj.phoneNumbers[0] = new Proxy(observedObj.phoneNumbers[0], {});
+      observedObj.phoneNumbers[1] = new Proxy(observedObj.phoneNumbers[1], {});
+      //end external proxification
+
+      observedObj.phoneNumbers[0].number = '123';
+
+      const patches = jsonPatcherProxy.generate();
+      expect(patches).toReallyEqual([
+        {
+          op: 'replace',
+          path: '/phoneNumbers/0/number',
+          value: '123'
+        }
+      ]);
+    });
 
     it('should generate replace (changes in new array cell, primitive values)', function() {
       var arr = [1];


### PR DESCRIPTION
Fixes #35 through refactoring of the metadata access layer and adding a new check to the trap of "set".

#### Benchmark results

### Before this PR

```julia
jsonpatcherproxy generate operation
 Ops/sec: 95630 ±4.20% Ran 7111 times in 0.074 seconds.
jsonpatch generate operation
 Ops/sec: 158564 ±4.14% Ran 9171 times in 0.058 seconds.
jsonpatcherproxy mutation - huge object
 Ops/sec: 839 ±4.87% Ran 56 times in 0.067 seconds.
jsonpatch mutation - huge object
 Ops/sec: 989 ±2.64% Ran 55 times in 0.056 seconds.
jsonpatcherproxy generate operation - huge object
 Ops/sec: 869 ±4.87% Ran 56 times in 0.064 seconds.
jsonpatch generate operation - huge object
 Ops/sec: 980 ±2.79% Ran 55 times in 0.056 seconds.
PROXIFY big object
 Ops/sec: 1671 ±4.91% Ran 109 times in 0.065 seconds.
DIRTY-OBSERVE big object
 Ops/sec: 1945 ±2.70% Ran 109 times in 0.056 seconds.
```

### After this PR

```julia
jsonpatcherproxy generate operation
 Ops/sec: 89850 ±4.54% Ran 6729 times in 0.075 seconds.
jsonpatch generate operation
 Ops/sec: 155485 ±3.85% Ran 9117 times in 0.059 seconds.
jsonpatcherproxy mutation - huge object
 Ops/sec: 832 ±5.00% Ran 57 times in 0.069 seconds.
jsonpatch mutation - huge object
 Ops/sec: 988 ±2.60% Ran 55 times in 0.056 seconds.
jsonpatcherproxy generate operation - huge object
 Ops/sec: 807 ±5.01% Ran 53 times in 0.066 seconds.
jsonpatch generate operation - huge object
 Ops/sec: 979 ±2.74% Ran 55 times in 0.056 seconds.
PROXIFY big object
 Ops/sec: 1666 ±5.03% Ran 111 times in 0.067 seconds.
DIRTY-OBSERVE big object
 Ops/sec: 1932 ±3.28% Ran 109 times in 0.056 seconds.
```