### PR TITLE
Nice things (test refactor) from PR 39

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "webpack",
     "build-watch": "webpack --watch",
     "bench": "node test/spec/proxyBenchmark.js",
+    "bench-compare": "node test/spec/proxyBenchmark.js --compare",
     "test": "jasmine DUPLEX=proxy JASMINE_CONFIG_PATH=test/jasmine.json",
     "test-debug": "node --inspect-brk node_modules/jasmine/bin/jasmine.js DUPLEX=proxy JASMINE_CONFIG_PATH=test/jasmine.json",
     "version": "webpack && git add -A"

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -1,9 +1,23 @@
+/*
+  To run with comparisons:
+  $ npm run bench-compare
+
+  To run without comparisons:
+  $ npm run bench
+  */
+
+let includeComparisons = true;
+
 if (typeof window === 'undefined') {
   const jsdom = require("jsdom");
   const { JSDOM } = jsdom;
   const dom = new JSDOM();
   global.window = dom.window;
   global.document = dom.window.document;
+
+  if (!process.argv.includes("--compare")) {
+    includeComparisons = false;
+  }
 }
 
 if (typeof jsonpatch === 'undefined') {
@@ -59,7 +73,7 @@ function reverseString(str) {
 {
   const suiteName = 'Observe and generate, small object';
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (noop)`, function() {
       const obj = generateBigObjectFixture(1);
       modifyObj(obj);
@@ -76,7 +90,7 @@ function reverseString(str) {
     });
   }
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (fast-json-patch)`, function() {
       const obj = generateBigObjectFixture(1);
       const observer = jsonpatch.observe(obj);
@@ -91,7 +105,7 @@ function reverseString(str) {
 {
   const suiteName = 'Observe and generate';
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (noop)`, function() {
       const obj = generateBigObjectFixture(100);
       modifyObj(obj);
@@ -108,7 +122,7 @@ function reverseString(str) {
     });
   }
   
-  {
+  if (includeComparisons) {
     suite.add(`${suiteName} (fast-json-patch)`, function() {
       const obj = generateBigObjectFixture(100);
       const observer = jsonpatch.observe(obj);
@@ -123,7 +137,7 @@ function reverseString(str) {
 {
   const suiteName = 'Primitive mutation';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     
     suite.add(`${suiteName} (noop)`, function() {
@@ -141,7 +155,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
     
@@ -157,7 +171,7 @@ function reverseString(str) {
 {
   const suiteName = 'Complex mutation';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
   
     suite.add(`${suiteName} (noop)`, function() {
@@ -177,7 +191,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
   
@@ -194,7 +208,7 @@ function reverseString(str) {
 {
   const suiteName = 'Serialization';
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
   
     suite.add(`${suiteName} (noop)`, function() {
@@ -212,7 +226,7 @@ function reverseString(str) {
     });
   }
 
-  {
+  if (includeComparisons) {
     const obj = generateBigObjectFixture(100);
     const observer = jsonpatch.observe(obj);
   

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -1,9 +1,7 @@
-var obj, obj2;
-
 if (typeof window === 'undefined') {
   const jsdom = require("jsdom");
   const { JSDOM } = jsdom;
-  var dom = new JSDOM();
+  const dom = new JSDOM();
   global.window = dom.window;
   global.document = dom.window.document;
 }
@@ -22,10 +20,10 @@ if (typeof Benchmark === 'undefined') {
     .benchmarkResultsToConsole;
 }
 
-var suite = new Benchmark.Suite();
+const suite = new Benchmark.Suite();
 
-suite.add('jsonpatcherproxy generate operation', function() {
-  var obj = {
+function generateDeepObjectFixture() {
+  return {
     firstName: 'Albert',
     lastName: 'Einstein',
     phoneNumbers: [
@@ -36,187 +34,89 @@ suite.add('jsonpatcherproxy generate operation', function() {
         number: '45353'
       }
     ]
-  };
+  }
+}
 
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
+function generateSmallObjectFixture() {
+  return { name: 'Tesla', speed: 100 };
+}
 
-  var patches = jsonPatcherProxy.generate();
-
-  observedObj.firstName = 'Joachim';
-  observedObj.lastName = 'Wester';
-  observedObj.phoneNumbers[0].number = '123';
-  observedObj.phoneNumbers[1].number = '456';
-});
-suite.add('jsonpatch generate operation', function() {
-  var observedObj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    phoneNumbers: [
-      {
-        number: '12345'
-      },
-      {
-        number: '45353'
-      }
-    ]
-  };
-  var observer = jsonpatch.observe(observedObj);
-
-  observedObj.firstName = 'Joachim';
-  observedObj.lastName = 'Wester';
-  observedObj.phoneNumbers[0].number = '123';
-  observedObj.phoneNumbers[1].number = '456';
-
-  jsonpatch.generate(observer);
-});
-
-
-
-
-
-suite.add('jsonpatcherproxy mutation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
+function generateBigObjectFixture(carsSize) {
+  const obj = {
     firstName: 'Albert',
     lastName: 'Einstein',
     cars: []
   };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
+  for (let i = 0; i < carsSize; i++) {
+    let deep = generateSmallObjectFixture();
+    obj.cars.push(deep);
+    for (let j = 0; j < 5; j++) {
+      deep.temp = generateSmallObjectFixture();
+      deep = deep.temp;
     }
-    obj.cars.push(copy);
   }
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
+  return obj;
+}
 
+suite.add('jsonpatcherproxy generate operation', function() {
+  const obj = generateDeepObjectFixture();
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
+  const patches = jsonPatcherProxy.generate();
+  observedObj.firstName = 'Joachim';
+  observedObj.lastName = 'Wester';
+  observedObj.phoneNumbers[0].number = '123';
+  observedObj.phoneNumbers[1].number = '456';
+});
+
+suite.add('jsonpatch generate operation', function() {
+  const obj = generateDeepObjectFixture();
+  const observer = jsonpatch.observe(obj);
+  obj.firstName = 'Joachim';
+  obj.lastName = 'Wester';
+  obj.phoneNumbers[0].number = '123';
+  obj.phoneNumbers[1].number = '456';
+  jsonpatch.generate(observer);
+});
+
+suite.add('jsonpatcherproxy mutation - huge object', function() {
+  const obj = generateBigObjectFixture(100);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.cars[50].name = 'Toyota'
 });
 
 suite.add('jsonpatch mutation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var observer = jsonpatch.observe(obj);
-
+  const obj = generateBigObjectFixture(100);
+  const observer = jsonpatch.observe(obj);
   obj.cars[50].name = 'Toyota';
-
   jsonpatch.generate(observer);
 });
 
 suite.add('jsonpatcherproxy generate operation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-  var observedObj = jsonPatcherProxy.observe(true);
-
+  const obj = generateBigObjectFixture(100);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.cars.shift();
 });
 
 suite.add('jsonpatch generate operation - huge object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-
-  for (var i = 0; i < 100; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var observer = jsonpatch.observe(obj);
-
+  const obj = generateBigObjectFixture(100);
+  const observer = jsonpatch.observe(obj);
   obj.cars.shift();
-
   jsonpatch.generate(observer);
 });
 
 suite.add('PROXIFY big object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-  for (var i = 0; i < 50; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-
-  var jsonPatcherProxy = new JSONPatcherProxy(obj);
-
-  var observedObj = jsonPatcherProxy.observe(true);
+  const obj = generateBigObjectFixture(50);
+  const jsonPatcherProxy = new JSONPatcherProxy(obj);
+  const observedObj = jsonPatcherProxy.observe(true);
   observedObj.a = 1;
 });
 
 suite.add('DIRTY-OBSERVE big object', function() {
-  var singleCar = { name: 'Tesla', speed: 100 };
-
-  var obj = {
-    firstName: 'Albert',
-    lastName: 'Einstein',
-    cars: []
-  };
-  for (var i = 0; i < 50; i++) {
-    var copy = JSONPatcherProxy.deepClone(singleCar);
-    var temp = copy;
-    for (var j = 0; j < 5; j++) {
-      temp.temp = JSONPatcherProxy.deepClone(singleCar);
-      temp = temp.temp;
-    }
-    obj.cars.push(copy);
-  }
-  var observer = jsonpatch.observe(obj);
+  const obj = generateBigObjectFixture(50);
+  const observer = jsonpatch.observe(obj);
   obj.a = 1;
   jsonpatch.generate(observer);
 

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -191,6 +191,39 @@ function reverseString(str) {
 
 /* ============================= */
 
+{
+  const suiteName = 'Serialization';
+
+  {
+    const obj = generateBigObjectFixture(100);
+  
+    suite.add(`${suiteName} (noop)`, function() {
+      JSON.stringify(obj);
+    });
+  }
+
+  {
+    const obj = generateBigObjectFixture(100);
+    const jsonPatcherProxy = new JSONPatcherProxy(obj);
+    const observedObj = jsonPatcherProxy.observe(true);
+  
+    suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
+      JSON.stringify(observedObj);
+    });
+  }
+
+  {
+    const obj = generateBigObjectFixture(100);
+    const observer = jsonpatch.observe(obj);
+  
+    suite.add(`${suiteName} (fast-json-patch)`, function() {
+      JSON.stringify(obj);
+    });
+  }
+}
+
+/* ============================= */
+
 // if we are in the browser with benchmark < 2.1.2
 if (typeof benchmarkReporter !== 'undefined') {
   benchmarkReporter(suite);

--- a/test/spec/proxyBenchmark.js
+++ b/test/spec/proxyBenchmark.js
@@ -85,8 +85,8 @@ function reverseString(str) {
       const obj = generateBigObjectFixture(1);
       const jsonPatcherProxy = new JSONPatcherProxy(obj);
       const observedObj = jsonPatcherProxy.observe(true);
-      const patches = jsonPatcherProxy.generate();
       modifyObj(observedObj);
+      jsonPatcherProxy.generate();
     });
   }
   
@@ -117,8 +117,8 @@ function reverseString(str) {
       const obj = generateBigObjectFixture(100);
       const jsonPatcherProxy = new JSONPatcherProxy(obj);
       const observedObj = jsonPatcherProxy.observe(true);
-      const patches = jsonPatcherProxy.generate();
       modifyObj(observedObj);
+      jsonPatcherProxy.generate();
     });
   }
   
@@ -152,6 +152,7 @@ function reverseString(str) {
     
     suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
       observedObj.cars[50].name = reverseString(observedObj.cars[50].name);
+      jsonPatcherProxy.generate();
     });
   }
 
@@ -188,6 +189,7 @@ function reverseString(str) {
     suite.add(`${suiteName} (JSONPatcherProxy)`, function() {
       const item = observedObj.cars.shift();
       observedObj.cars.push(item);
+      jsonPatcherProxy.generate();
     });
   }
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -124,7 +124,7 @@ describe('proxy', function() {
       expect(obj2).toReallyEqual(observedObj);
     });
     it('should generate replace (escaped chars)', function() {
-      var obj = {
+      const obj = {
         '/name/first': 'Albert',
         '/name/last': 'Einstein',
         '~phone~/numbers': [
@@ -136,6 +136,7 @@ describe('proxy', function() {
           }
         ]
       };
+      const obj2 = JSON.parse(JSON.stringify(obj));
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -145,19 +146,6 @@ describe('proxy', function() {
       observedObj['~phone~/numbers'][1].number = '456';
 
       var patches = jsonPatcherProxy.generate();
-      var obj2 = {
-        '/name/first': 'Albert',
-        '/name/last': 'Einstein',
-        '~phone~/numbers': [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
       jsonpatch.applyPatch(obj2, patches);
 
       /* iOS and Android */
@@ -278,18 +266,10 @@ describe('proxy', function() {
       /* iOS and Android */
       observedObj = JSONPatcherProxy.deepClone(observedObj);
 
-      expect(observedObj).toReallyEqual({
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '123'
-          },
-          {
-            number: '456'
-          }
-        ]
-      }); //objects should be still the same
+      const obj2 = generateDeepObjectFixture();
+      obj2.phoneNumbers[0].number = '123';
+      obj2.phoneNumbers[1].number = '456';
+      expect(observedObj).toReallyEqual(obj2); //objects should be still the same
     });
 
     it('should generate replace (changes in new array cell, primitive values)', function() {
@@ -416,18 +396,7 @@ describe('proxy', function() {
 
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
       expect(obj2).toEqualInJson(observedObj);
     });
@@ -981,18 +950,10 @@ describe('proxy', function() {
         }
       ]); //first patch should NOT be reported again here
 
-      expect(observedObj).toReallyEqual({
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '123'
-          },
-          {
-            number: '456'
-          }
-        ]
-      });
+      const obj2 = generateDeepObjectFixture();
+      obj2.phoneNumbers[0].number = '123';
+      obj2.phoneNumbers[1].number = '456';
+      expect(observedObj).toReallyEqual(obj2);
     });
 
     describe(

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -24,6 +24,21 @@ function getPatchesUsingCompare(objFactory, objChanger) {
   return jsonpatch.compare(mirror, JSON.parse(JSON.stringify(obj)));
 }
 
+function generateDeepObjectFixture() {
+  return {
+    firstName: 'Albert',
+    lastName: 'Einstein',
+    phoneNumbers: [
+      {
+        number: '12345'
+      },
+      {
+        number: '45353'
+      }
+    ]
+  }
+}
+
 var customMatchers = {
   /**
      * This matcher is only needed in Chrome 28 (Chrome 28 cannot successfully compare observed objects immediately after they have been changed. Chrome 30 is unaffected)
@@ -88,18 +103,7 @@ describe('proxy', function() {
 
   describe('generate', function() {
     it('should generate replace', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -111,18 +115,7 @@ describe('proxy', function() {
 
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
 
       /* iOS and Android */
@@ -212,19 +205,7 @@ describe('proxy', function() {
     });
 
     it('should generate replace (double change, shallow object)', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -268,19 +249,7 @@ describe('proxy', function() {
     });
 
     it('should generate replace (double change, deep object)', function() {
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -419,14 +388,7 @@ describe('proxy', function() {
       ]);
     });
     it('should generate add', function() {
-      var obj = {
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -438,31 +400,12 @@ describe('proxy', function() {
       });
       var patches = jsonPatcherProxy.generate();
 
-      var obj2 = {
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          }
-        ]
-      };
-
+      var obj2 = generateDeepObjectFixture();
       jsonpatch.applyPatch(obj2, patches);
       expect(obj2).toEqualInJson(observedObj);
     });
     it('should generate remove', function() {
-      var obj = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -489,18 +432,7 @@ describe('proxy', function() {
       expect(obj2).toEqualInJson(observedObj);
     });
     it('should generate remove and disable all traps', function() {
-      var obj = {
-        lastName: 'Einstein',
-        firstName: 'Albert',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '4234'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -937,18 +869,7 @@ describe('proxy', function() {
   describe('callback', function() {
     it('should generate replace', function() {
       var obj2;
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
 
@@ -959,18 +880,7 @@ describe('proxy', function() {
       observedObj.firstName = 'Joachim';
 
       function objChanged(operation) {
-        obj2 = {
-          firstName: 'Albert',
-          lastName: 'Einstein',
-          phoneNumbers: [
-            {
-              number: '12345'
-            },
-            {
-              number: '45353'
-            }
-          ]
-        };
+        obj2 = generateDeepObjectFixture();
         jsonpatch.applyOperation(obj2, operation);
 
         /* iOS and Android */
@@ -984,18 +894,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0;
 
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
 
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
@@ -1051,18 +950,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0;
 
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
 
       var observedObj = jsonPatcherProxy.observe(true);
@@ -1200,18 +1088,7 @@ describe('proxy', function() {
       var lastPatches,
         called = 0,
         res;
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
+        const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;
@@ -1427,20 +1304,7 @@ describe('proxy', function() {
   describe('pausing and resuming', function() {
     it("shouldn't emit patches when paused", function() {
       var called = 0;
-
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;
@@ -1460,20 +1324,7 @@ describe('proxy', function() {
 
     it('Should re-start emitting patches when paused then resumed', function() {
       var called = 0;
-
-      var obj = {
-        firstName: 'Albert',
-        lastName: 'Einstein',
-        phoneNumbers: [
-          {
-            number: '12345'
-          },
-          {
-            number: '45353'
-          }
-        ]
-      };
-
+      const obj = generateDeepObjectFixture();
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true, function(patches) {
         called++;


### PR DESCRIPTION
PR #39 contains discussable changes that downgrade performance, but also refactoring of the test suite.

Since I don't want to merge performance degradation until absolutely required, I decided to make another PR with things that are easier to agree with. 

In fact, these changes were already agreed, because PR #39 got a green light for merging. Just in case, @tomalec please give a quick review again. Changes are only in `package.json` and tests.

Changes are explained in the commit messages, but here's a short summary:
- DRY-er unit tests and benchmark suites
- more meaningful benchmark suites (e.g. for getting data from the observed object)
- old command `npm run bench` does not compare with `fast-json-patch` anymore
- new command `npm run bench-compare` compares with `fast-json-patch` and no-op

I think this can be merged to `master` before PRs #39 and #41, then I can open new rebased PRs for #39 and #41 (this won't take long).

#### Benchmark formatting before this PR:

```julia
jsonpatcherproxy generate operation
 Ops/sec: 144269 ±2.90% Ran 9277 times in 0.064 seconds.
jsonpatch generate operation
 Ops/sec: 97748 ±7.24% Ran 6095 times in 0.062 seconds.
jsonpatcherproxy mutation - huge object
 Ops/sec: 790 ±3.76% Ran 50 times in 0.063 seconds.
jsonpatch mutation - huge object
 Ops/sec: 761 ±2.86% Ran 45 times in 0.059 seconds.
jsonpatcherproxy generate operation - huge object
 Ops/sec: 708 ±4.18% Ran 46 times in 0.065 seconds.
jsonpatch generate operation - huge object
 Ops/sec: 851 ±1.40% Ran 47 times in 0.055 seconds.
PROXIFY big object
 Ops/sec: 1805 ±2.05% Ran 104 times in 0.058 seconds.
DIRTY-OBSERVE big object
 Ops/sec: 1697 ±1.17% Ran 93 times in 0.055 seconds.
```


#### Benchmark formatting after this PR:

```julia
Observe and generate, small object (noop)
 Ops/sec: 12434413 ±0.39% Ran 637179 times in 0.051 seconds.
Observe and generate, small object (JSONPatcherProxy)
 Ops/sec: 95511 ±2.74% Ran 5983 times in 0.063 seconds.
Observe and generate, small object (fast-json-patch)
 Ops/sec: 68608 ±1.63% Ran 3780 times in 0.055 seconds.
Observe and generate (noop)
 Ops/sec: 164602 ±0.30% Ran 8453 times in 0.051 seconds.
Observe and generate (JSONPatcherProxy)
 Ops/sec: 1893 ±1.92% Ran 204 times in 0.108 seconds.
Observe and generate (fast-json-patch)
 Ops/sec: 1650 ±0.98% Ran 95 times in 0.058 seconds.
Primitive mutation (noop)
 Ops/sec: 2601631 ±0.32% Ran 132729 times in 0.051 seconds.
Primitive mutation (JSONPatcherProxy)
 Ops/sec: 524799 ±0.19% Ran 26797 times in 0.051 seconds.
Primitive mutation (fast-json-patch)
 Ops/sec: 7955 ±0.36% Ran 409 times in 0.051 seconds.
Complex mutation (noop)
 Ops/sec: 6382115 ±0.23% Ran 325296 times in 0.051 seconds.
Complex mutation (JSONPatcherProxy)
 Ops/sec: 8731 ±0.30% Ran 448 times in 0.051 seconds.
Complex mutation (fast-json-patch)
 Ops/sec: 8281 ±0.26% Ran 424 times in 0.051 seconds.
Serialization (noop)
 Ops/sec: 7036 ±0.38% Ran 365 times in 0.052 seconds.
Serialization (JSONPatcherProxy)
 Ops/sec: 1278 ±0.34% Ran 66 times in 0.052 seconds.
Serialization (fast-json-patch)
 Ops/sec: 7092 ±0.49% Ran 365 times in 0.051 seconds.
```