### PR TITLE
Don't generate patch for a no-change set operation

### DIFF
--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -137,8 +137,9 @@ const JSONPatcherProxy = (function() {
       operation.op = 'add';
       if (tree.hasOwnProperty(key)) {
         if (typeof tree[key] !== 'undefined') {
-          if (tree[key] == newValue)
+          if (tree[key] == newValue) {
             return true; // Value wasn't actually changed, pretend set was successful but don't generate a patch
+          }
           operation.op = 'replace';
         } else if (isTreeAnArray) {
           operation.op = 'replace'; // setting `undefined` array elements is a `replace` op

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -118,6 +118,8 @@ const JSONPatcherProxy = (function() {
     if (isTreeAnArray && !isNonSerializableArrayProperty) {
       const index = parseInt(key, 10);
       if (index > tree.length) {
+        // force call trapForSet for implicit undefined elements of the array added by the JS engine
+        // because JSON-Patch spec prohibits adding an index that is higher than array.length
         trapForSet(instance, tree, (index - 1) + '', undefined);
       }
     }

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -136,7 +136,11 @@ const JSONPatcherProxy = (function() {
       }
       operation.op = 'add';
       if (tree.hasOwnProperty(key)) {
-        if (typeof tree[key] !== 'undefined' || isTreeAnArray) {
+        if (typeof tree[key] !== 'undefined') {
+          if (tree[key] == newValue)
+            return true; // Value wasn't actually changed, pretend set was successful but don't generate a patch
+          operation.op = 'replace';
+        } else if (isTreeAnArray) {
           operation.op = 'replace'; // setting `undefined` array elements is a `replace` op
         }
       }

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -682,14 +682,14 @@ describe('proxy', function() {
             obj.baz = undefined;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual([]);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
 
         it('when an `undefined` property is deleted', function() {
@@ -703,14 +703,14 @@ describe('proxy', function() {
             delete obj.foo;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual([]);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
       });
 
@@ -726,20 +726,20 @@ describe('proxy', function() {
             obj.foo = 'something';
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'add',
               path: '/foo',
               value: 'something'
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
 
         it('`undefined` property is set to `null`', function() {
@@ -753,20 +753,20 @@ describe('proxy', function() {
             obj.foo = null;
           };
 
-          var genereatedPatches = getPatchesUsingGenerate(
+          var generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           var comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'add',
               path: '/foo',
               value: null
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
       });
 
@@ -782,19 +782,19 @@ describe('proxy', function() {
             obj.foo = undefined;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'remove',
               path: '/foo'
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
 
         it('property with `null` value is set to `undefined`', function() {
@@ -808,19 +808,19 @@ describe('proxy', function() {
             obj.foo = undefined;
           };
 
-          var genereatedPatches = getPatchesUsingGenerate(
+          var generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           var comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'remove',
               path: '/foo'
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
       });
 
@@ -836,20 +836,20 @@ describe('proxy', function() {
             obj.foo[1] = undefined;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'replace',
               path: '/foo/1',
               value: null
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
         it('`undefined` array element is set to something', function() {
           const objFactory = function() {
@@ -862,20 +862,20 @@ describe('proxy', function() {
             obj.foo[1] = 1;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
 
-          expect(genereatedPatches).toReallyEqual([
+          expect(generatedPatches).toReallyEqual([
             {
               op: 'replace',
               path: '/foo/1',
               value: 1
             }
           ]);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
         });
       });
     });
@@ -899,13 +899,13 @@ describe('proxy', function() {
         obj.foo[6] = 'bar';
       };
 
-      var genereatedPatches = getPatchesUsingGenerate(
+      var generatedPatches = getPatchesUsingGenerate(
         objFactory,
         objChanger
       );
       var expectedPatches = [];
 
-      expect(genereatedPatches).toReallyEqual(expectedPatches);
+      expect(generatedPatches).toReallyEqual(expectedPatches);
     });
 
     it('in objects', function() {
@@ -929,13 +929,13 @@ describe('proxy', function() {
         obj.foo.h = undefined;
       };
 
-      var genereatedPatches = getPatchesUsingGenerate(
+      var generatedPatches = getPatchesUsingGenerate(
         objFactory,
         objChanger
       );
       var expectedPatches = [];
 
-      expect(genereatedPatches).toReallyEqual(expectedPatches);
+      expect(generatedPatches).toReallyEqual(expectedPatches);
     });
   });
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -782,12 +782,13 @@ describe('proxy', function() {
             obj.arr[8] = undefined;
           };
 
-          const genereatedPatches = getPatchesUsingGenerate(
+          const generatedPatches = getPatchesUsingGenerate(
             objFactory,
             objChanger
           );
           const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
-          expect(genereatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual(comparedPatches);
+          expect(generatedPatches).toReallyEqual([{ op: 'add', path: '/arr/5', value: null }, { op: 'add', path: '/arr/6', value: null }, { op: 'add', path: '/arr/7', value: null }, { op: 'add', path: '/arr/8', value: null }]);
         });
       });
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -768,6 +768,27 @@ describe('proxy', function() {
           ]);
           expect(generatedPatches).toReallyEqual(comparedPatches);
         });
+
+        it('Array extended with `null` or `undefined` element', function () {
+          const objFactory = function() {
+            return {
+              arr: Array(5)
+            };
+          };
+
+          const objChanger = function(obj) {
+            obj.arr[7];
+            obj.arr[7] = null;
+            obj.arr[8] = undefined;
+          };
+
+          const genereatedPatches = getPatchesUsingGenerate(
+            objFactory,
+            objChanger
+          );
+          const comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
+          expect(genereatedPatches).toReallyEqual(comparedPatches);
+        });
       });
 
       describe('should generate remove, when', function() {

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -378,6 +378,7 @@ describe('proxy', function() {
       observedObj.phoneNumbers.push({
         number: '456'
       });
+      observedObj.nothing = null;
       var patches = jsonPatcherProxy.generate();
 
       var obj2 = generateDeepObjectFixture();
@@ -727,6 +728,33 @@ describe('proxy', function() {
           ]);
           expect(genereatedPatches).toReallyEqual(comparedPatches);
         });
+
+        it('`undefined` property is set to `null`', function() {
+          var objFactory = function() {
+            return {
+              foo: undefined
+            };
+          };
+
+          var objChanger = function(obj) {
+            obj.foo = null;
+          };
+
+          var genereatedPatches = getPatchesUsingGenerate(
+            objFactory,
+            objChanger
+          );
+          var comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
+
+          expect(genereatedPatches).toReallyEqual([
+            {
+              op: 'add',
+              path: '/foo',
+              value: null
+            }
+          ]);
+          expect(genereatedPatches).toReallyEqual(comparedPatches);
+        });
       });
 
       describe('should generate remove, when', function() {
@@ -734,6 +762,32 @@ describe('proxy', function() {
           var objFactory = function() {
             return {
               foo: 'bar'
+            };
+          };
+
+          var objChanger = function(obj) {
+            obj.foo = undefined;
+          };
+
+          var genereatedPatches = getPatchesUsingGenerate(
+            objFactory,
+            objChanger
+          );
+          var comparedPatches = getPatchesUsingCompare(objFactory, objChanger);
+
+          expect(genereatedPatches).toReallyEqual([
+            {
+              op: 'remove',
+              path: '/foo'
+            }
+          ]);
+          expect(genereatedPatches).toReallyEqual(comparedPatches);
+        });
+
+        it('property with `null` value is set to `undefined`', function() {
+          var objFactory = function() {
+            return {
+              foo: null
             };
           };
 
@@ -811,6 +865,64 @@ describe('proxy', function() {
           expect(genereatedPatches).toReallyEqual(comparedPatches);
         });
       });
+    });
+  });
+
+  describe('no-change operations should generate empty patch', function () {
+    it('in arrays', function() {
+      var objFactory = function() {
+        return {
+          foo: [0, undefined, null, undefined, null, 2, 'bar']
+        };
+      };
+
+      var objChanger = function(obj) {
+        obj.foo[0] = 0;
+        obj.foo[1] = undefined;
+        obj.foo[2] = null;
+        obj.foo[3] = null;
+        obj.foo[4] = undefined;
+        obj.foo[5] = 2;
+        obj.foo[6] = 'bar';
+      };
+
+      var genereatedPatches = getPatchesUsingGenerate(
+        objFactory,
+        objChanger
+      );
+      var expectedPatches = [];
+
+      expect(genereatedPatches).toReallyEqual(expectedPatches);
+    });
+
+    it('in objects', function() {
+      var objFactory = function() {
+        return {
+          foo:{
+            a: 0,
+            b: undefined,
+            c: null,
+            f: 2,
+            g: 'bar'}
+        };
+      };
+
+      var objChanger = function(obj) {
+        obj.foo.a = 0;
+        obj.foo.b = undefined;
+        obj.foo.c = null;
+        obj.foo.f = 2;
+        obj.foo.g = 'bar';
+        obj.foo.h = undefined;
+      };
+
+      var genereatedPatches = getPatchesUsingGenerate(
+        objFactory,
+        objChanger
+      );
+      var expectedPatches = [];
+
+      expect(genereatedPatches).toReallyEqual(expectedPatches);
     });
   });
 


### PR DESCRIPTION
Extending the example in README.md like this:

```JS
var myObj = { firstName:"Joachim", lastName:"Wester", contactDetails: { phoneNumbers: [ { number:"555-123" }] } };
var jsonPatcherProxy = new JSONPatcherProxy( myObj );
var observedObject = jsonPatcherProxy.observe(true);
observedObject.firstName = "Albert";
observedObject.firstName = "Albert";
observedObject.firstName = "Albert";
observedObject.contactDetails.phoneNumbers[0].number = "123";
observedObject.contactDetails.phoneNumbers.push({number:"456"});
var patches = jsonPatcherProxy.generate();
```

results in the following patch:

```JSON
[
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/contactDetails/phoneNumbers/0/number","value":"123"},
  {"op":"add","path":"/contactDetails/phoneNumbers/1","value":{"number":"456"}}
]
```

The second and third time `firstName` is set are effectively no-ops which have already been communicated. I think this is wrong. The proposed change recognizes this and renders the following result instead:

```JSON
[
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/contactDetails/phoneNumbers/0/number","value":"123"},
  {"op":"add","path":"/contactDetails/phoneNumbers/1","value":{"number":"456"}}
]
```
