### PR TITLE
Make sure collected patches are not mutated.

### DIFF
--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -140,7 +140,11 @@ const JSONPatcherProxy = (function() {
           operation.op = 'replace'; // setting `undefined` array elements is a `replace` op
         }
       }
-      operation.value = newValue;
+      if (newValue === null || typeof(newValue) !== 'object') {
+        operation.value = newValue;
+      } else {
+        operation.value = JSON.parse(JSON.stringify(newValue));
+      }
     }
     const reflectionResult = Reflect.set(tree, key, newValue);
     instance._defaultCallback(operation);


### PR DESCRIPTION
Extending the example in README.md like this:

```JS
var myObj = { firstName:"Joachim", lastName:"Wester", contactDetails: { phoneNumbers: [ { number:"555-123" }] } };
var jsonPatcherProxy = new JSONPatcherProxy( myObj );
var observedObject = jsonPatcherProxy.observe(true);
observedObject.firstName = "Albert";
observedObject.contactDetails.phoneNumbers[0].number = "123";
observedObject.contactDetails.phoneNumbers.push({number:"456"});
observedObject.contactDetails.phoneNumbers[1].number = "789";
var patches = jsonPatcherProxy.generate();
```

results in the following patch:

```JSON
[
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/contactDetails/phoneNumbers/0/number","value":"123"},
  {"op":"add","path":"/contactDetails/phoneNumbers/1","value":{"number":"789"}}
  {"op":"replace","path":"/contactDetails/phoneNumbers/1/number","value":"789"},
]
```

Note that the last change mutates the already collected patch corresponding to the push operation. The proposed change prevents this by deep-cloning the value placed in the patch so that the result is as expected instead:

```JSON
[
  {"op":"replace","path":"/firstName","value":"Albert"},
  {"op":"replace","path":"/contactDetails/phoneNumbers/0/number","value":"123"},
  {"op":"add","path":"/contactDetails/phoneNumbers/1","value":{"number":"456"}}
  {"op":"replace","path":"/contactDetails/phoneNumbers/1/number","value":"789"},
]
```
