### PR TITLE
do not proxify objects that are values of non-patchable array properties

### DIFF
--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -94,6 +94,7 @@ const JSONPatcherProxy = (function() {
 
     let warnedAboutNonIntegrerArrayProp = false;
     const isTreeAnArray = Array.isArray(tree);
+    const isNonSerializableArrayProperty = isTreeAnArray && !Number.isInteger(+key.toString());
 
     // if the new value is an object, make sure to watch it
     if (
@@ -101,7 +102,7 @@ const JSONPatcherProxy = (function() {
       typeof newValue == 'object' &&
       !instance._treeMetadataMap.has(newValue)
     ) {
-      if (isTreeAnArray && !Number.isInteger(+key.toString())) {
+      if (isNonSerializableArrayProperty) {
         // This happens in Vue 1-2 (should not happen in Vue 3). See: https://github.com/vuejs/vue/issues/427, https://github.com/vuejs/vue/issues/9259
         console.warn(`JSONPatcherProxy noticed a non-integer property ('${key}') was set for an array. This interception will not emit a patch. The value is an object, but it was not proxified, because it would not be addressable in JSON-Pointer`);
         warnedAboutNonIntegrerArrayProp = true;
@@ -136,7 +137,7 @@ const JSONPatcherProxy = (function() {
         }
       }
     } else {
-      if (isTreeAnArray && !Number.isInteger(+key.toString())) {
+      if (isNonSerializableArrayProperty) {
         /* array props (as opposed to indices) don't emit any patches, to avoid needless `length` patches */
         if(key != 'length' && !warnedAboutNonIntegrerArrayProp) {
           console.warn(`JSONPatcherProxy noticed a non-integer property ('${key}') was set for an array. This interception will not emit a patch`);

--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -93,6 +93,7 @@ const JSONPatcherProxy = (function() {
     }
 
     let warnedAboutNonIntegrerArrayProp = false;
+    const isTreeAnArray = Array.isArray(tree);
 
     // if the new value is an object, make sure to watch it
     if (
@@ -100,9 +101,9 @@ const JSONPatcherProxy = (function() {
       typeof newValue == 'object' &&
       !instance._treeMetadataMap.has(newValue)
     ) {
-      if (Array.isArray(tree) && !Number.isInteger(+key.toString())) {
+      if (isTreeAnArray && !Number.isInteger(+key.toString())) {
         // This happens in Vue 1-2 (should not happen in Vue 3). See: https://github.com/vuejs/vue/issues/427, https://github.com/vuejs/vue/issues/9259
-        console.warn(`JSONPatcherProxy noticed a non-integer property ('${key}') was set for an array. This interception will not emit a patch. The value of this property is an object, but it was not proxified, because only arrays only can have numeric properties in JSON-Pointer`);
+        console.warn(`JSONPatcherProxy noticed a non-integer property ('${key}') was set for an array. This interception will not emit a patch. The value is an object, but it was not proxified, because it would not be addressable in JSON-Pointer`);
         warnedAboutNonIntegrerArrayProp = true;
       }
       else {
@@ -115,7 +116,6 @@ const JSONPatcherProxy = (function() {
       op: 'remove',
       path: pathToKey
     };
-    const isTreeAnArray = Array.isArray(tree);
     if (typeof newValue == 'undefined') {
       // applying De Morgan's laws would be a tad faster, but less readable
       if (!isTreeAnArray && !tree.hasOwnProperty(key)) {

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -482,9 +482,9 @@ describe('proxy', function() {
     });
 
     it('should not proxify an object that is assigned as an array prop - and log a warning', function() {
-      var obj = [];
-      var jsonPatcherProxy = new JSONPatcherProxy(obj);
-      var observedObj = jsonPatcherProxy.observe(true);
+      const obj = [];
+      const jsonPatcherProxy = new JSONPatcherProxy(obj);
+      const observedObj = jsonPatcherProxy.observe(true);
 
       spyOn(console, 'warn');
 
@@ -495,7 +495,7 @@ describe('proxy', function() {
 
       expect(console.warn).toHaveBeenCalledWith("JSONPatcherProxy noticed a non-integer property ('person') was set for an array. This interception will not emit a patch. The value is an object, but it was not proxified, because it would not be addressable in JSON-Pointer");
 
-      var patches = jsonPatcherProxy.generate();
+      const patches = jsonPatcherProxy.generate();
       expect(patches).toReallyEqual([]);
     });
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -469,7 +469,7 @@ describe('proxy', function() {
     });
 
     it('should not generate a patch when array props are added or replaced - and log a warning', function() {
-      
+
       var obj = [];
       var jsonPatcherProxy = new JSONPatcherProxy(obj);
       var observedObj = jsonPatcherProxy.observe(true);
@@ -478,7 +478,25 @@ describe('proxy', function() {
 
       observedObj.lastName = 'Wester';
 
-      expect(console.warn).toHaveBeenCalledWith('JSONPatcherProxy noticed a non-integer prop was set for an array. This will not emit a patch');
+      expect(console.warn).toHaveBeenCalledWith("JSONPatcherProxy noticed a non-integer property ('lastName') was set for an array. This interception will not emit a patch");
+    });
+
+    it('should not proxify an object that is assigned as an array prop - and log a warning', function() {
+      var obj = [];
+      var jsonPatcherProxy = new JSONPatcherProxy(obj);
+      var observedObj = jsonPatcherProxy.observe(true);
+
+      spyOn(console, 'warn');
+
+      observedObj.person = {
+        name: "Albert"
+      };
+      observedObj.person.name = "Joachim";
+
+      expect(console.warn).toHaveBeenCalledWith("JSONPatcherProxy noticed a non-integer property ('person') was set for an array. This interception will not emit a patch. The value of this property is an object, but it was not proxified, because only arrays only can have numeric properties in JSON-Pointer");
+
+      var patches = jsonPatcherProxy.generate();
+      expect(patches).toReallyEqual([]);
     });
 
     it('should not generate the same patch twice (replace)', function() {
@@ -1024,7 +1042,7 @@ describe('proxy', function() {
             var observedObj = jsonPatcherProxy.observe(true, function(_patches) {
               expect(observedObj.numbers[0]).toReallyEqual(100);
             });
-            
+
             observedObj.numbers[0] = 100;
           });
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -467,7 +467,9 @@ describe('proxy', function() {
     });
 
     it('should not generate a patch when array props are added or replaced - and log a warning', function() {
-
+      const obj = [];
+      const jsonPatcherProxy = new JSONPatcherProxy(obj);
+      const observedObj = jsonPatcherProxy.observe(true);
 
       spyOn(console, 'warn');
 

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -493,7 +493,7 @@ describe('proxy', function() {
       };
       observedObj.person.name = "Joachim";
 
-      expect(console.warn).toHaveBeenCalledWith("JSONPatcherProxy noticed a non-integer property ('person') was set for an array. This interception will not emit a patch. The value of this property is an object, but it was not proxified, because only arrays only can have numeric properties in JSON-Pointer");
+      expect(console.warn).toHaveBeenCalledWith("JSONPatcherProxy noticed a non-integer property ('person') was set for an array. This interception will not emit a patch. The value is an object, but it was not proxified, because it would not be addressable in JSON-Pointer");
 
       var patches = jsonPatcherProxy.generate();
       expect(patches).toReallyEqual([]);


### PR DESCRIPTION
because such problem happens in Vue 2 and it results in an invalid patch. See: https://github.com/vuejs/vue/issues/427, https://github.com/vuejs/vue/issues/9259