### PR TITLE
Make sure collected patches are not mutated (continuation)

### DIFF
--- a/src/jsonpatcherproxy.js
+++ b/src/jsonpatcherproxy.js
@@ -140,7 +140,11 @@ const JSONPatcherProxy = (function() {
           operation.op = 'replace'; // setting `undefined` array elements is a `replace` op
         }
       }
-      operation.value = newValue;
+      if (newValue === null || typeof(newValue) !== 'object') {
+        operation.value = newValue;
+      } else {
+        operation.value = JSON.parse(JSON.stringify(newValue));
+      }
     }
     const reflectionResult = Reflect.set(tree, key, newValue);
     instance._defaultCallback(operation);

--- a/test/spec/proxySpec.js
+++ b/test/spec/proxySpec.js
@@ -547,6 +547,21 @@ describe('proxy', function() {
       expect(patches).toReallyEqual([]);
     });
 
+    it('should not modify already generated patch', function() {
+      var obj = generateDeepObjectFixture();
+      var jsonPatcherProxy = new JSONPatcherProxy(obj);
+      var observedObj = jsonPatcherProxy.observe(true);
+
+      observedObj.phoneNumbers.push({number:"456"});
+      observedObj.phoneNumbers[2].number = "789";
+
+      var patches = jsonPatcherProxy.generate();
+      expect(patches).toReallyEqual([
+        { op: 'add', path: '/phoneNumbers/2', value: { number: '456' } },
+        { op: 'replace', path: '/phoneNumbers/2/number', value: '789' }
+      ]);
+    });
+
     it('should ignore array properties', function() {
       var obj = {
         array: [1, 2, 3]


### PR DESCRIPTION
Continuation of https://github.com/Palindrom/JSONPatcherProxy/pull/46 with test and performance improvement.

cc @eriksunsol

There is a serious degradation in performance (see "Complex mutation"), but I think it is an important fix. @tomalec WDYT?

## Performance before this PR (`npm run bench`)

```julia
Observe and generate, small object (JSONPatcherProxy)
 Ops/sec: 78007 ±4.53% Ran 5595 times in 0.072 seconds.
Observe and generate (JSONPatcherProxy)
 Ops/sec: 1909 ±2.49% Ran 250 times in 0.131 seconds.
Primitive mutation (JSONPatcherProxy)
 Ops/sec: 504531 ±0.92% Ran 25937 times in 0.051 seconds.
Complex mutation (JSONPatcherProxy)
 Ops/sec: 12758 ±0.28% Ran 651 times in 0.051 seconds.
Serialization (JSONPatcherProxy)
 Ops/sec: 2089 ±0.47% Ran 107 times in 0.051 seconds.
```

## Performance after this PR (`npm run bench`)

```julia
Observe and generate, small object (JSONPatcherProxy)
 Ops/sec: 78382 ±3.97% Ran 5371 times in 0.069 seconds.
Observe and generate (JSONPatcherProxy)
 Ops/sec: 1902 ±2.26% Ran 230 times in 0.121 seconds.
Primitive mutation (JSONPatcherProxy)
 Ops/sec: 521039 ±0.74% Ran 26589 times in 0.051 seconds.
Complex mutation (JSONPatcherProxy)
 Ops/sec: 2201 ±0.21% Ran 112 times in 0.051 seconds.
Serialization (JSONPatcherProxy)
 Ops/sec: 2106 ±0.18% Ran 107 times in 0.051 seconds.
```