### PR TITLE
Corrected glitch with type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,4 +72,4 @@ declare class JSONPatcherProxy<T> {
      */
     public pause(): void;
 }
-export default JSONPatcherProxy;
+export { JSONPatcherProxy };


### PR DESCRIPTION
The type definitions indicate that JSONPatcherProxy is a default reference, but it isn't. It's a named reference, so this PR just changes the type definition file to account for this.

Without this change, in typescript this shows no error:
    import JSONPatcherProxy from 'jsonpatcherproxy';
but at runtime I get:
    TypeError: jsonpatcherproxy_1.default is not a constructor

And if I try to use a named import:
    import { JSONPatcherProxy } from 'jsonpatcherproxy';
I get a "has no exported member 'JSONPatcherProxy'" error.

With this change, the named imports satisfy typescript and work at runtime.